### PR TITLE
amd-fftw fix wrong parameter type with ompi 5.0.1

### DIFF
--- a/patches/rocm-6.1.1/amd-fftw/0001-fix-parameter-type-for-openmpi-5.0.1.patch
+++ b/patches/rocm-6.1.1/amd-fftw/0001-fix-parameter-type-for-openmpi-5.0.1.patch
@@ -1,0 +1,71 @@
+From 7d168fcd8b3d015fb9d06876e2d43e8cc38f8efe Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Wed, 29 May 2024 15:16:57 -0700
+Subject: [PATCH] fix parameter type for openmpi 5.0.1
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+detected on fedora 40/gcc build that
+at least OpenMPI 5.0.1 request that last
+parameter on some function calls needs to be
+MPI_Request instead of MPI_Status
+
+original build error
+/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/amd-fftw/mpi/transpose-pairwise-omc.c:108:115: error: passing argument 7 of ‘MPI_Isend’ from incompatible pointer type [-Wincompatible-pointer-types]
+  108 |                    MPI_Isend(buf[j&0x1], (int) (sbs[pe]), FFTW_MPI_TYPE, pe, (my_pe * n_pes + pe) & 0xffff, comm, &send_status);
+      |                                                                                                                   ^~~~~~~~~~~~
+      |                                                                                                                   |
+      |                                                                                                                   MPI_Status * {aka struct ompi_status_public_t *}
+libtool: compile:  mpicc -DHAVE_CONFIG_H -I. -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/amd-fftw/mpi -I.. -I /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/amd-fftw -I /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/amd-fftw/api -I/opt/rocm_sdk_611/include -I/opt/rocm_sdk_611/hsa/include -I/opt/rocm_sdk_611/rocm_smi/include -I/opt/rocm_sdk_611/rocblas/include -I/opt/rocm_sdk_611/include -I/opt/rocm_sdk_611/hsa/include -I/opt/rocm_sdk_611/rocm_smi/include -I/opt/rocm_sdk_611/rocblas/include -mno-avx256-split-unaligned-store -mno-avx256-split-unaligned-load -mno-prefer-avx128 -MT dft-rank-geq2-transposed.lo -MD -MP -MF .deps/dft-rank-geq2-transposed.Tpo -c /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/amd-fftw/mpi/dft-rank-geq2-transposed.c  -fPIC -DPIC -o .libs/dft-rank-geq2-transposed.o
+In file included from /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/amd-fftw/mpi/ifftw-mpi.h:28,
+                 from /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/amd-fftw/mpi/mpi-transpose.h:22,
+                 from /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/amd-fftw/mpi/transpose-pairwise-omc.c:32:
+/opt/rocm_sdk_611/include/mpi.h:1783:67: note: expected ‘struct ompi_request_t **’ but argument is of type ‘MPI_Status *’ {aka ‘struct ompi_status_public_t *’}
+ 1783 |                              int tag, MPI_Comm comm, MPI_Request *request);
+      |                                                      ~~~~~~~~~~~~~^~~~~~~
+/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/amd-fftw/mpi/transpose-pairwise-omc.c:109:116: error: passing argument 7 of ‘MPI_Irecv’ from incompatible pointer type [-Wincompatible-pointer-types]
+  109 |                    MPI_Irecv(O + rbo[pe], (int) (rbs[pe]), FFTW_MPI_TYPE, pe, (pe * n_pes + my_pe) & 0xffff, comm, &recv_status);
+      |                                                                                                                    ^~~~~~~~~~~~
+      |                                                                                                                    |
+      |                                                                                                                    MPI_Status * {aka struct ompi_status_public_t *}
+/opt/rocm_sdk_611/include/mpi.h:1779:67: note: expected ‘struct ompi_request_t **’ but argument is of type ‘MPI_Status *’ {aka ‘struct ompi_status_public_t *’}
+ 1779 |                              int tag, MPI_Comm comm, MPI_Request *request);
+      |                                                      ~~~~~~~~~~~~~^~~~~~~
+/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/amd-fftw/mpi/transpose-pairwise-omc.c:113:29: error: passing argument 1 of ‘MPI_Wait’ from incompatible pointer type [-Wincompatible-pointer-types]
+  113 |                    MPI_Wait(&send_status, MPI_STATUS_IGNORE);
+      |                             ^~~~~~~~~~~~
+      |                             |
+      |                             MPI_Status * {aka struct ompi_status_public_t *}
+/opt/rocm_sdk_611/include/mpi.h:2099:42: note: expected ‘struct ompi_request_t **’ but argument is of type ‘MPI_Status *’ {aka ‘struct ompi_status_public_t *’}
+ 2099 | OMPI_DECLSPEC  int MPI_Wait(MPI_Request *request, MPI_Status *status);
+      |                             ~~~~~~~~~~~~~^~~~~~~
+/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/amd-fftw/mpi/transpose-pairwise-omc.c:114:29: error: passing argument 1 of ‘MPI_Wait’ from incompatible pointer type [-Wincompatible-pointer-types]
+  114 |                    MPI_Wait(&recv_status, MPI_STATUS_IGNORE);
+      |                             ^~~~~~~~~~~~
+      |                             |
+      |                             MPI_Status * {aka struct ompi_status_public_t *}
+/opt/rocm_sdk_611/include/mpi.h:2099:42: note: expected ‘struct ompi_request_t **’ but argument is of type ‘MPI_Status *’ {aka ‘struct ompi_status_public_t *’}
+ 2099 | OMPI_DECLSPEC  int MPI_Wait(MPI_Request *request, MPI_Status *status);
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ mpi/transpose-pairwise-omc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mpi/transpose-pairwise-omc.c b/mpi/transpose-pairwise-omc.c
+index 41b588c7..298ab644 100644
+--- a/mpi/transpose-pairwise-omc.c
++++ b/mpi/transpose-pairwise-omc.c
+@@ -71,7 +71,7 @@ static void transpose_chunks(int *sched, int n_pes, int my_pe,
+            buf[1] = bufs[1];
+ #endif
+            int pe = sched[0], pe2, j=0;
+-           MPI_Status send_status, recv_status;
++           MPI_Request send_status, recv_status;
+ 
+ #ifdef AMD_MPI_TRANSPOSE_LOGS
+            printf("TRANSPOSE-PAIRWISE: n_pes[%d], my_pe[%d], first_pe[%d]\n", n_pes, my_pe, pe);
+-- 
+2.45.1
+


### PR DESCRIPTION
fixes detected on fedora40/gcc 14 build

fixes: https://github.com/lamikr/rocm_sdk_builder/issues/12