### PR TITLE
AMDMiGraphX Fedora 40 build error fix

### DIFF
--- a/patches/rocm-6.1.1/AMDMIGraphX/0001-fix-no-matching-constructor-build-error.patch
+++ b/patches/rocm-6.1.1/AMDMIGraphX/0001-fix-no-matching-constructor-build-error.patch
@@ -1,7 +1,7 @@
-From a60531a70d6bc67d9c2e4253987d41f4ef8dac15 Mon Sep 17 00:00:00 2001
+From 3567e09b96983fb9593218cdcc290579a169e2d7 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Thu, 9 May 2024 09:11:08 -0700
-Subject: [PATCH 1/2] fix no matching constructor build error
+Subject: [PATCH 1/3] fix no matching constructor build error
 
 fix the build error for no matching constructor
 by type casting auto arguments x and y to int.
@@ -53,5 +53,5 @@ index bf6807afb..3f9ac1f1e 100644
          return result;
      }
 -- 
-2.41.0
+2.45.1
 

--- a/patches/rocm-6.1.1/AMDMIGraphX/0002-add-gfx1010-and-gfx1035.patch
+++ b/patches/rocm-6.1.1/AMDMIGraphX/0002-add-gfx1010-and-gfx1035.patch
@@ -1,7 +1,7 @@
-From 81e67876eadf2c9bd82d9e983e8bed7d1d9f33db Mon Sep 17 00:00:00 2001
+From e8b47071e093630f6945a359a028230dd7838a09 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Thu, 9 May 2024 13:12:33 -0700
-Subject: [PATCH 2/2] add gfx1010 and gfx1035
+Subject: [PATCH 2/3] add gfx1010 and gfx1035
 
 Signed-off-by: Mika Laitio <lamikr@pilppa.org>
 ---
@@ -22,5 +22,5 @@ index 1d701ad89..ebb892650 100644
  }
  
 -- 
-2.41.0
+2.45.1
 

--- a/patches/rocm-6.1.1/AMDMIGraphX/0003-define-detail-namespace-only-if-used.patch
+++ b/patches/rocm-6.1.1/AMDMIGraphX/0003-define-detail-namespace-only-if-used.patch
@@ -1,0 +1,50 @@
+From 95ed53dfcf1a6cafff1ab08d22305a9ae94552ce Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Thu, 30 May 2024 09:51:05 -0700
+Subject: [PATCH 3/3] define detail namespace only if used
+
+This fixes the build problen on Fedora, not
+sure whether the real reason is some kind of optimization.
+Tested first that following did not help:
+	#ifndef HAS_EXCEPTION_PTR
+		#define HAS_EXCEPTION_PTR
+	#endif
+
+Builded ok on Fedora 39 and Ubuntu 23.10 but had following error in Fedora 40:
+cd /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/test && /opt/rocm_sdk_611/bin/clang++ -DHAVE_GPU -DMIGRAPHX_HAS_EXECUTORS=0 -DMIGRAPHX_HAS_FIND_2_API -DMIGRAPHX_HAS_FIND_MODE_API -DMIGRAPHX_PREALLOCATE_MIOPEN_BUFFERS -DMIGRAPHX_USE_ROCBLAS_FP8_API -DMIGRAPHX_USE_ROCBLAS_TUNING_API -DROCBLAS_BETA_FEATURES_API -DROCBLAS_NO_DEPRECATED_WARNINGS -DUSE_PROF_API=1 -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_AMD__=1 -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/test/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/src/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/src/onnx/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/src/tf/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/src/targets/ref/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/targets/ref/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/src/targets/gpu/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/targets/gpu/include -isystem /opt/rocm_sdk_611/include -O3 -DNDEBUG -std=c++17 -Wall -Wextra -Wcomment -Wendif-labels -Wformat -Winit-self -Wreturn-type -Wsequence-point -Wswitch -Wtrigraphs -Wundef -Wuninitialized -Wunreachable-code -Wunused -Wno-sign-compare -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-conversion -Wno-double-promotion -Wno-exit-time-destructors -Wno-extra-semi -Wno-extra-semi-stmt -Wno-float-conversion -Wno-gnu-anonymous-struct -Wno-gnu-zero-variadic-macro-arguments -Wno-missing-prototypes -Wno-nested-anon-types -Wno-option-ignored -Wno-padded -Wno-shorten-64-to-32 -Wno-sign-conversion -Wno-unused-command-line-argument -Wno-weak-vtables -Wno-c99-extensions -Wno-unsafe-buffer-usage -MD -MT test/CMakeFiles/header_src_include_migraphx_execution_environment_hpp.dir/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp.o -MF CMakeFiles/header_src_include_migraphx_execution_environment_hpp.dir/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp.o.d -o CMakeFiles/header_src_include_migraphx_execution_environment_hpp.dir/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp.o -c /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/test/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp
+In file included from /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/test/header-main-include-header_src_include_migraphx_convolution_hpp.cpp:2:
+In file included from /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/include/migraphx/convolution.hpp:29:
+In file included from /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/include/migraphx/par_for.hpp:27:
+/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/include/migraphx/par.hpp:58:22: error: no member named 'exception_ptr' in namespace 'std'
+   58 |     std::vector<std::exception_ptr> exceptions;
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ src/include/migraphx/par.hpp | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/include/migraphx/par.hpp b/src/include/migraphx/par.hpp
+index 270d0f07b..46b27f516 100644
+--- a/src/include/migraphx/par.hpp
++++ b/src/include/migraphx/par.hpp
+@@ -37,6 +37,8 @@
+ namespace migraphx {
+ inline namespace MIGRAPHX_INLINE_NS {
+ 
++#if MIGRAPHX_HAS_EXECUTORS
++
+ namespace detail {
+ 
+ struct exception_list
+@@ -71,6 +73,8 @@ struct exception_list
+ 
+ } // namespace detail
+ 
++#endif
++
+ template <class InputIt, class OutputIt, class UnaryOperation>
+ OutputIt par_transform(InputIt first1, InputIt last1, OutputIt d_first, UnaryOperation unary_op)
+ {
+-- 
+2.45.1
+


### PR DESCRIPTION
Enable code for exception_ptr only if it is used.
Not sure whether this error was caused by optimizion as patch was not needed on Fedora 39, Ubuntu 23.10 or on Mageia 9.

Error message was:
AMDMIGraphX/src/include/migraphx/par.hpp:58:22: error: no member named 'exception_ptr' in namespace 'std'

Fixes: https://github.com/lamikr/rocm_sdk_builder/issues/12