### PR TITLE
pytorch Fedora 40 fix for maybe-uninitialized

### DIFF
--- a/patches/rocm-6.1.1/pytorch/0001-pytorch_rocm-build-and-package-scripts.patch
+++ b/patches/rocm-6.1.1/pytorch/0001-pytorch_rocm-build-and-package-scripts.patch
@@ -1,7 +1,7 @@
-From 19ce4ef2bb0c475d96e1ee163106e139ad4b0e2a Mon Sep 17 00:00:00 2001
+From e3509eae726e4bca1f61f9bb17686c0802a57faa Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Mon, 11 Dec 2023 09:20:07 -0800
-Subject: [PATCH 1/6] pytorch_rocm build and package scripts
+Subject: [PATCH 1/7] pytorch_rocm build and package scripts
 
 Signed-off-by: Mika Laitio <lamikr@gmail.com>
 ---
@@ -79,5 +79,5 @@ index 00000000000..8b3272e6c49
 +unset PKG_CONFIG_PATH
 +USE_FLASH_ATTENTION=OFF CMAKE_PREFIX_PATH="${install_dir_prefix_rocm};${install_dir_prefix_rocm}/lib64 python" tools/amd_build/build_amd.py
 -- 
-2.41.0
+2.45.1
 

--- a/patches/rocm-6.1.1/pytorch/0002-show-error-message-if-ROCM_SOURCE_DIR-not-defined.patch
+++ b/patches/rocm-6.1.1/pytorch/0002-show-error-message-if-ROCM_SOURCE_DIR-not-defined.patch
@@ -1,7 +1,7 @@
-From 3412edb6b3d1de4c248545e8119db93166468db2 Mon Sep 17 00:00:00 2001
+From 2fe6791d47bb3d9ad1c094b855bba014063bd363 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 10 May 2024 10:16:19 -0700
-Subject: [PATCH 2/6] show error message if ROCM_SOURCE_DIR not defined
+Subject: [PATCH 2/7] show error message if ROCM_SOURCE_DIR not defined
 
 ROCM_SOURCE_DIR is required by by third_party/kineto module
 and if it is not set, kineto will not find the
@@ -31,5 +31,5 @@ index a96075245ae..8befd5b8294 100644
    endif()
  
 -- 
-2.41.0
+2.45.1
 

--- a/patches/rocm-6.1.1/pytorch/0003-LoadHIP-force-ROCM-detection-and-patches.patch
+++ b/patches/rocm-6.1.1/pytorch/0003-LoadHIP-force-ROCM-detection-and-patches.patch
@@ -1,7 +1,7 @@
-From 4236f483dee69086c951476c43892dd0a3f90d52 Mon Sep 17 00:00:00 2001
+From 5046c437018a4c32307721657df7f2e8e5fe0404 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 10 May 2024 10:32:33 -0700
-Subject: [PATCH 3/6] LoadHIP force ROCM detection and patches
+Subject: [PATCH 3/7] LoadHIP force ROCM detection and patches
 
 - set HIP_ROOT_DIR to ROCM_PATH which is set
   by the build scripts
@@ -72,5 +72,5 @@ index f6ca263c5e5..0f7a61cf141 100644
    message("\n***** Library versions from dpkg *****\n")
    execute_process(COMMAND dpkg -l COMMAND grep rocm-dev COMMAND awk "{print $2 \" VERSION: \" $3}")
 -- 
-2.41.0
+2.45.1
 

--- a/patches/rocm-6.1.1/pytorch/0004-LoadHIP-lib-and-lib64-search-path-adjustements.patch
+++ b/patches/rocm-6.1.1/pytorch/0004-LoadHIP-lib-and-lib64-search-path-adjustements.patch
@@ -1,7 +1,7 @@
-From 5982f2026cb9bf8f3c6454178a11f6b818de7218 Mon Sep 17 00:00:00 2001
+From 268f465c7d2b4123aeb50c09c0d92e3f6f8f4478 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 10 May 2024 11:11:47 -0700
-Subject: [PATCH 4/6] LoadHIP lib and lib64 search path adjustements
+Subject: [PATCH 4/7] LoadHIP lib and lib64 search path adjustements
 
 - search both lib and lib64 directories
   (note some libs still installed to lib-dir
@@ -116,5 +116,5 @@ index 0f7a61cf141..dfa4bab4df2 100644
    if(ROCM_VERSION_DEV VERSION_GREATER_EQUAL "5.7.0")
      # check whether hipblaslt is using its own datatype
 -- 
-2.41.0
+2.45.1
 

--- a/patches/rocm-6.1.1/pytorch/0005-fix-gcc-parameter-is-null-optimization-error.patch
+++ b/patches/rocm-6.1.1/pytorch/0005-fix-gcc-parameter-is-null-optimization-error.patch
@@ -1,7 +1,7 @@
-From c79128a679e6b389715f4aec64008b9081926fa0 Mon Sep 17 00:00:00 2001
+From 1047827e6b7d8e57e2109e083d553e8efe597624 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 10 May 2024 19:25:50 -0700
-Subject: [PATCH 5/6] fix gcc parameter is null optimization error
+Subject: [PATCH 5/7] fix gcc parameter is null optimization error
 
 https://github.com/pytorch/pytorch/issues/112089
 and
@@ -29,5 +29,5 @@ index 42b67d8cb25..0bc7f79b709 100644
  
  if(INSTALL_TEST)
 -- 
-2.41.0
+2.45.1
 

--- a/patches/rocm-6.1.1/pytorch/0006-cherry-pick-hipify-fix-from-never-version.patch
+++ b/patches/rocm-6.1.1/pytorch/0006-cherry-pick-hipify-fix-from-never-version.patch
@@ -1,7 +1,7 @@
-From 627e619e7c890204c8f9b5a254245fdb6e604d0c Mon Sep 17 00:00:00 2001
+From adbb347de92db04c15acfc9d1bd7c3ca62c95f34 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Tue, 21 May 2024 20:17:36 -0700
-Subject: [PATCH 6/6] cherry-pick hipify fix from never version
+Subject: [PATCH 6/7] cherry-pick hipify fix from never version
 
 Signed-off-by: Mika Laitio <lamikr@gmail.com>
 ---
@@ -29,5 +29,5 @@ index 3dd5a8caf32..569191edbd1 100644
              "cuda_texture_types.h",
              ("hip/hip_texture_types.h", CONV_INCLUDE, API_RUNTIME),
 -- 
-2.41.0
+2.45.1
 

--- a/patches/rocm-6.1.1/pytorch/0007-Maybe-uninitialized-error-fix-for-Fedora-40.patch
+++ b/patches/rocm-6.1.1/pytorch/0007-Maybe-uninitialized-error-fix-for-Fedora-40.patch
@@ -1,0 +1,25 @@
+From 2296735a9e3d8c5062111b95f8ea749e6569b306 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Fri, 31 May 2024 11:34:17 -0700
+Subject: [PATCH 7/7] Maybe uninitialized error fix for Fedora 40
+
+- Occurs on fbgemm submodule with Fedora 40/gcc 14
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ build_pytorch_rocm.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build_pytorch_rocm.sh b/build_pytorch_rocm.sh
+index 5973cb1ffac..c98fe22cb02 100755
+--- a/build_pytorch_rocm.sh
++++ b/build_pytorch_rocm.sh
+@@ -20,4 +20,4 @@ unset LDFLAGS
+ unset CFLAGS
+ unset CPPFLAGS
+ unset PKG_CONFIG_PATH
+-USE_FLASH_ATTENTION=OFF ROCM_PATH=${install_dir_prefix_rocm} ROCM_SOURCE_DIR=${install_dir_prefix_rocm} CMAKE_PREFIX_PATH="${install_dir_prefix_rocm};${install_dir_prefix_rocm}/lib64/cmake;${install_dir_prefix_rocm}/lib/cmake;${install_dir_prefix_rocm}/lib64;${install_dir_prefix_rocm}/lib" ROCM_VERSION=${rocm_version_str} HIP_ROOT_DIR=${install_dir_prefix_rocm} USE_ROCM=1 python setup.py install
++USE_FLASH_ATTENTION=OFF ROCM_PATH=${install_dir_prefix_rocm} ROCM_SOURCE_DIR=${install_dir_prefix_rocm} CMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS -Wno-error=maybe-uninitialized" CMAKE_PREFIX_PATH="${install_dir_prefix_rocm};${install_dir_prefix_rocm}/lib64/cmake;${install_dir_prefix_rocm}/lib/cmake;${install_dir_prefix_rocm}/lib64;${install_dir_prefix_rocm}/lib" ROCM_VERSION=${rocm_version_str} HIP_ROOT_DIR=${install_dir_prefix_rocm} USE_ROCM=1 python setup.py install
+-- 
+2.45.1
+


### PR DESCRIPTION
Fedora 40/gcc 14 gives maybe-uninitialized error
from fbgemm submodule. Disable the warning for now.

Fixes: https://github.com/lamikr/rocm_sdk_builder/issues/12