### PR TITLE
onnxruntime fedora 40 build fixes

### DIFF
--- a/patches/rocm-6.1.1/onnxruntime/0001-onnxruntime-training-rocm-sdk-builder-script.patch
+++ b/patches/rocm-6.1.1/onnxruntime/0001-onnxruntime-training-rocm-sdk-builder-script.patch
@@ -1,7 +1,7 @@
-From b08d7f1a84bda691402a3bea22453639e376703f Mon Sep 17 00:00:00 2001
+From 9e1670018ce2e945407f3f364f0be1b4536b38dc Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Mon, 20 May 2024 14:02:57 -0700
-Subject: [PATCH 1/7] onnxruntime training rocm sdk builder script
+Subject: [PATCH 1/9] onnxruntime training rocm sdk builder script
 
 Signed-off-by: Mika Laitio <lamikr@gmail.com>
 ---
@@ -45,5 +45,5 @@ index 0000000000..9f31121b84
 @@ -0,0 +1 @@
 +pip install ./build/Linux/Release/dist/onnxruntime_training*.whl
 -- 
-2.40.1
+2.45.1
 

--- a/patches/rocm-6.1.1/onnxruntime/0002-fix-circular-dependency-error-with-DeepSpeed.patch
+++ b/patches/rocm-6.1.1/onnxruntime/0002-fix-circular-dependency-error-with-DeepSpeed.patch
@@ -1,7 +1,7 @@
-From 2de1f3a0f061b2282671514b3215bf5316cf83bc Mon Sep 17 00:00:00 2001
+From ea33051c7477ec8098aab66c2337a26acdd3b81b Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Mon, 20 May 2024 22:21:15 -0700
-Subject: [PATCH 2/7] fix circular dependency error with DeepSpeed
+Subject: [PATCH 2/9] fix circular dependency error with DeepSpeed
 
 discussed here:
 https://github.com/ROCm/onnxruntime/commit/1caf38252b120caf64e891c2f1b8eb64e94fad97
@@ -49,5 +49,5 @@ index 779b6bfe50..fda6e345da 100755
  
              configure_ort_compatible_zero_stage3(debug=False, stats_output_dir="ort_output", stats_overwrite=True)
 -- 
-2.40.1
+2.45.1
 

--- a/patches/rocm-6.1.1/onnxruntime/0003-added-migraphx-integration.patch
+++ b/patches/rocm-6.1.1/onnxruntime/0003-added-migraphx-integration.patch
@@ -1,7 +1,7 @@
-From 1417f6bf787353845849b6c919a6a699a9e952d1 Mon Sep 17 00:00:00 2001
+From a7be1af8268571a19b5ac8e23fa3167eb9d5d545 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Wed, 22 May 2024 11:09:43 -0700
-Subject: [PATCH 3/7] added migraphx integration
+Subject: [PATCH 3/9] added migraphx integration
 
 Signed-off-by: Mika Laitio <lamikr@pilppa.org>
 ---
@@ -22,5 +22,5 @@ index 769dac0c37..8462abfa05 100755
  #
  #./build.sh --config RelWithDebInfo --build_shared_lib --parallel --compile_no_warning_as_error --skip_submodule_sync
 -- 
-2.40.1
+2.45.1
 

--- a/patches/rocm-6.1.1/onnxruntime/0004-composable-kernel-patches-to-support-gfx1010-and-gfx.patch
+++ b/patches/rocm-6.1.1/onnxruntime/0004-composable-kernel-patches-to-support-gfx1010-and-gfx.patch
@@ -1,7 +1,7 @@
-From 176fa348c281938d0fe6a79f5c8e4276c3250b77 Mon Sep 17 00:00:00 2001
+From ca9f5b51a12846b58f6b9274961be64b5aaf808a Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Fri, 24 May 2024 16:03:37 -0700
-Subject: [PATCH 4/7] composable kernel patches to support gfx1010 and gfx1035
+Subject: [PATCH 4/9] composable kernel patches to support gfx1010 and gfx1035
 
 add onnxruntime composable kernel patches required
 to build onxxruntime for gfx1010 or gfx1030
@@ -270,5 +270,5 @@ index 0000000000..46a77fc78a
 +         clang_tidy_check(${INSTANCE_NAME})
 +         set(result 0)
 -- 
-2.40.1
+2.45.1
 

--- a/patches/rocm-6.1.1/onnxruntime/0005-gradient_builder.cc-dangling-reference-warning-fix.patch
+++ b/patches/rocm-6.1.1/onnxruntime/0005-gradient_builder.cc-dangling-reference-warning-fix.patch
@@ -1,7 +1,7 @@
-From a2d4623d93580745862cdc2ee66a6202801495f5 Mon Sep 17 00:00:00 2001
+From 7eba934eee44240fb037ebdef5486d4a852aaeef Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Fri, 24 May 2024 16:47:18 -0700
-Subject: [PATCH 5/7] gradient_builder.cc dangling reference warning fix
+Subject: [PATCH 5/9] gradient_builder.cc dangling reference warning fix
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -31,5 +31,5 @@ index e675b55c8a..50487a1a67 100755
        size_t n = static_cast<size_t>(input_shape.dim_size()) - 1;
        bw_perm.resize(n + 1);
 -- 
-2.40.1
+2.45.1
 

--- a/patches/rocm-6.1.1/onnxruntime/0006-disable-USE_NEURAL_SPEED-due-to-overload-function-er.patch
+++ b/patches/rocm-6.1.1/onnxruntime/0006-disable-USE_NEURAL_SPEED-due-to-overload-function-er.patch
@@ -1,7 +1,7 @@
-From 198f740b66e322dc48b373fd7ee5b2836d1493d7 Mon Sep 17 00:00:00 2001
+From 0e448307fb58d3e740d569caa86c3266f4bb2a9d Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Fri, 24 May 2024 16:50:39 -0700
-Subject: [PATCH 6/7] disable USE_NEURAL_SPEED due to overload function error
+Subject: [PATCH 6/9] disable USE_NEURAL_SPEED due to overload function error
 
 - build error for overloaded functions
   causes build break on ubuntu and fedora
@@ -35,5 +35,5 @@ index 3b0503fe66..ed115341a8 100644
          target_compile_options(${target_name} PRIVATE "$<$<COMPILE_LANGUAGE:HIP>:SHELL:${FLAG}>")
        endforeach()
 -- 
-2.40.1
+2.45.1
 

--- a/patches/rocm-6.1.1/onnxruntime/0007-rocm-sdk-builder-CMAKE_PREFIX_PATHS.patch
+++ b/patches/rocm-6.1.1/onnxruntime/0007-rocm-sdk-builder-CMAKE_PREFIX_PATHS.patch
@@ -1,7 +1,7 @@
-From dfad4d02dabeeafaa74a32a650f9f4fdf8f1c577 Mon Sep 17 00:00:00 2001
+From cdf831c97f490e2bfc294b279d6c768585e7d448 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Fri, 24 May 2024 21:16:06 -0700
-Subject: [PATCH 7/7] rocm sdk builder CMAKE_PREFIX_PATHS
+Subject: [PATCH 7/9] rocm sdk builder CMAKE_PREFIX_PATHS
 
 Signed-off-by: Mika Laitio <lamikr@gmail.com>
 ---
@@ -45,5 +45,5 @@ index b662682915..fbc2408e8d 100644
    file(GLOB_RECURSE onnxruntime_providers_rocm_cc_srcs CONFIGURE_DEPENDS
      "${ONNXRUNTIME_ROOT}/core/providers/rocm/*.h"
 -- 
-2.40.1
+2.45.1
 

--- a/patches/rocm-6.1.1/onnxruntime/0008-template-id-not-allowed-for-constructor-in-C-20.patch
+++ b/patches/rocm-6.1.1/onnxruntime/0008-template-id-not-allowed-for-constructor-in-C-20.patch
@@ -1,0 +1,36 @@
+From d0c9bb6528d200cf1401a65f429d586a4ce5fad0 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Fri, 31 May 2024 11:08:25 -0700
+Subject: [PATCH 8/9] template-id not allowed for constructor in C++20
+
+following error in Fedora 40/gcc14
+
+In file included from onnxruntime/onnxruntime/core/providers/cpu/ml/tree_ensemble_common.h:6,
+                 from onnxruntime/onnxruntime/core/providers/cpu/ml/tree_ensemble_classifier.h:5,
+                 from onnxruntime/onnxruntime/core/providers/cpu/ml/tree_ensemble_classifier.cc:4:
+onnxruntime/onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h:329:59: error: template-id not allowed for constructor in C++20 [-Werror=template-id-cdtor]
+  329 |   TreeAggregatorMax<InputType, ThresholdType, OutputType>(size_t n_trees,
+
+fix: https://github.com/lamikr/rocm_sdk_builder/issues/12
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h b/onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h
+index b9f3050e59..896f2ad9af 100644
+--- a/onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h
++++ b/onnxruntime/core/providers/cpu/ml/tree_ensemble_aggregator.h
+@@ -326,7 +326,7 @@ class TreeAggregatorMin : public TreeAggregator<InputType, ThresholdType, Output
+ template <typename InputType, typename ThresholdType, typename OutputType>
+ class TreeAggregatorMax : public TreeAggregator<InputType, ThresholdType, OutputType> {
+  public:
+-  TreeAggregatorMax<InputType, ThresholdType, OutputType>(size_t n_trees,
++  TreeAggregatorMax(size_t n_trees,
+                                                           const int64_t& n_targets_or_classes,
+                                                           POST_EVAL_TRANSFORM post_transform,
+                                                           const std::vector<ThresholdType>& base_values) : TreeAggregator<InputType, ThresholdType, OutputType>(n_trees, n_targets_or_classes,
+-- 
+2.45.1
+

--- a/patches/rocm-6.1.1/onnxruntime/0009-fedora40-onnxruntime-optimized-maybe-uninitialized-e.patch
+++ b/patches/rocm-6.1.1/onnxruntime/0009-fedora40-onnxruntime-optimized-maybe-uninitialized-e.patch
@@ -1,0 +1,44 @@
+From 19deab3b4a9c1f2b3b874849dfc3e96233ebed4b Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Fri, 31 May 2024 11:13:28 -0700
+Subject: [PATCH 9/9] fedora40 onnxruntime optimized maybe-uninitialized error
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+- Did not find proper fix, so silence just now the warning
+  interpreted as an error on Fedora 40/gcc 14.
+  I found some discussion about possible fixes in /usr/include
+  headers in itself related to similar problem on cases
+  where inlining is used. Hard to say whether was the same root cause.
+
+inlined from ‘onnxruntime::SelectorActionTransformer::SelectorActionTransformer(const std::string&, onnxruntime::SelectorActionRegistry&&, const onnxruntime::SatApplyContextVariant&, const onnxruntime::InlinedHashSet<std::basic_string_view<char> >&)’ at onnxruntime/onnxruntime/core/optimizer/selectors_actions/selector_action_transformer.cc:77:7:
+/usr/include/c++/14/bits/std_function.h:243:11: error: ‘((std::_Function_base*)((char*)this + 16))[7].std::_Function_base::_M_manager’ may be used uninitialized [-Werror=maybe-uninitialized]
+  243 |       if (_M_manager)
+
+Fixes: https://github.com/lamikr/rocm_sdk_builder/issues/12
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ cmake/onnxruntime_optimizer.cmake | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/cmake/onnxruntime_optimizer.cmake b/cmake/onnxruntime_optimizer.cmake
+index f15d5b8dd6..fde6941769 100644
+--- a/cmake/onnxruntime_optimizer.cmake
++++ b/cmake/onnxruntime_optimizer.cmake
+@@ -107,6 +107,11 @@ endif()
+ 
+ onnxruntime_add_static_library(onnxruntime_optimizer ${onnxruntime_optimizer_srcs})
+ 
++# workaround for Fedora 40/gcc 14 maybe-uninitialized eror
++# onnxruntime/core/optimizer/selectors_actions/selector_action_transformer.cc:77:7:
++# /usr/include/c++/14/bits/std_function.h:243:11: error: ‘((std::_Function_base*)((char*)this + 16))[7].std::_Function_base::_M_manager’ may be used uninitialized [-Werror=maybe-uninitialized]
++set_property(TARGET onnxruntime_optimizer APPEND_STRING PROPERTY COMPILE_FLAGS "-Wno-error=maybe-uninitialized")
++
+ onnxruntime_add_include_to_target(onnxruntime_optimizer onnxruntime_common onnxruntime_framework onnx onnx_proto ${PROTOBUF_LIB} flatbuffers::flatbuffers Boost::mp11 safeint_interface)
+ target_include_directories(onnxruntime_optimizer PRIVATE ${ONNXRUNTIME_ROOT})
+ if (onnxruntime_ENABLE_TRAINING)
+-- 
+2.45.1
+


### PR DESCRIPTION
- fixes 2 build problems that showed up on onxxruntime 17.3 with Fedora 40.

Fixes: https://github.com/lamikr/rocm_sdk_builder/issues/12