### PR TITLE
AMDMIGraphX msgpack-cxx fix for Ubuntu 24.04

### DIFF
--- a/patches/rocm-6.1.1/AMDMIGraphX/0001-fix-no-matching-constructor-build-error.patch
+++ b/patches/rocm-6.1.1/AMDMIGraphX/0001-fix-no-matching-constructor-build-error.patch
@@ -1,7 +1,7 @@
-From 3567e09b96983fb9593218cdcc290579a169e2d7 Mon Sep 17 00:00:00 2001
+From 379bc45fc32b55dfafa44f7e83520298674e03db Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Thu, 9 May 2024 09:11:08 -0700
-Subject: [PATCH 1/3] fix no matching constructor build error
+Subject: [PATCH 1/4] fix no matching constructor build error
 
 fix the build error for no matching constructor
 by type casting auto arguments x and y to int.
@@ -53,5 +53,5 @@ index bf6807afb..3f9ac1f1e 100644
          return result;
      }
 -- 
-2.45.1
+2.43.0
 

--- a/patches/rocm-6.1.1/AMDMIGraphX/0002-add-gfx1010-and-gfx1035.patch
+++ b/patches/rocm-6.1.1/AMDMIGraphX/0002-add-gfx1010-and-gfx1035.patch
@@ -1,7 +1,7 @@
-From e8b47071e093630f6945a359a028230dd7838a09 Mon Sep 17 00:00:00 2001
+From ac148c4dcc2128bf2f6b93b18a6f696e26f9a13a Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Thu, 9 May 2024 13:12:33 -0700
-Subject: [PATCH 2/3] add gfx1010 and gfx1035
+Subject: [PATCH 2/4] add gfx1010 and gfx1035
 
 Signed-off-by: Mika Laitio <lamikr@pilppa.org>
 ---
@@ -22,5 +22,5 @@ index 1d701ad89..ebb892650 100644
  }
  
 -- 
-2.45.1
+2.43.0
 

--- a/patches/rocm-6.1.1/AMDMIGraphX/0003-define-detail-namespace-only-if-used.patch
+++ b/patches/rocm-6.1.1/AMDMIGraphX/0003-define-detail-namespace-only-if-used.patch
@@ -1,7 +1,7 @@
-From 95ed53dfcf1a6cafff1ab08d22305a9ae94552ce Mon Sep 17 00:00:00 2001
+From 080b788b22ecbb49b751303bf8e5e7cd45fbb58e Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Thu, 30 May 2024 09:51:05 -0700
-Subject: [PATCH 3/3] define detail namespace only if used
+Subject: [PATCH 3/4] define detail namespace only if used
 
 This fixes the build problen on Fedora, not
 sure whether the real reason is some kind of optimization.
@@ -11,11 +11,11 @@ Tested first that following did not help:
 	#endif
 
 Builded ok on Fedora 39 and Ubuntu 23.10 but had following error in Fedora 40:
-cd /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/test && /opt/rocm_sdk_611/bin/clang++ -DHAVE_GPU -DMIGRAPHX_HAS_EXECUTORS=0 -DMIGRAPHX_HAS_FIND_2_API -DMIGRAPHX_HAS_FIND_MODE_API -DMIGRAPHX_PREALLOCATE_MIOPEN_BUFFERS -DMIGRAPHX_USE_ROCBLAS_FP8_API -DMIGRAPHX_USE_ROCBLAS_TUNING_API -DROCBLAS_BETA_FEATURES_API -DROCBLAS_NO_DEPRECATED_WARNINGS -DUSE_PROF_API=1 -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_AMD__=1 -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/test/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/src/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/src/onnx/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/src/tf/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/src/targets/ref/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/targets/ref/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/src/targets/gpu/include -I/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/targets/gpu/include -isystem /opt/rocm_sdk_611/include -O3 -DNDEBUG -std=c++17 -Wall -Wextra -Wcomment -Wendif-labels -Wformat -Winit-self -Wreturn-type -Wsequence-point -Wswitch -Wtrigraphs -Wundef -Wuninitialized -Wunreachable-code -Wunused -Wno-sign-compare -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-conversion -Wno-double-promotion -Wno-exit-time-destructors -Wno-extra-semi -Wno-extra-semi-stmt -Wno-float-conversion -Wno-gnu-anonymous-struct -Wno-gnu-zero-variadic-macro-arguments -Wno-missing-prototypes -Wno-nested-anon-types -Wno-option-ignored -Wno-padded -Wno-shorten-64-to-32 -Wno-sign-conversion -Wno-unused-command-line-argument -Wno-weak-vtables -Wno-c99-extensions -Wno-unsafe-buffer-usage -MD -MT test/CMakeFiles/header_src_include_migraphx_execution_environment_hpp.dir/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp.o -MF CMakeFiles/header_src_include_migraphx_execution_environment_hpp.dir/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp.o.d -o CMakeFiles/header_src_include_migraphx_execution_environment_hpp.dir/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp.o -c /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/test/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp
-In file included from /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/builddir/035_AMDMIGraphX/test/header-main-include-header_src_include_migraphx_convolution_hpp.cpp:2:
-In file included from /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/include/migraphx/convolution.hpp:29:
-In file included from /home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/include/migraphx/par_for.hpp:27:
-/home/lamikr/own/rocm/src/sdk/rocm_sdk_builder_611/src_projects/AMDMIGraphX/src/include/migraphx/par.hpp:58:22: error: no member named 'exception_ptr' in namespace 'std'
+cd /builddir/035_AMDMIGraphX/test && /opt/rocm_sdk_611/bin/clang++ -DHAVE_GPU -DMIGRAPHX_HAS_EXECUTORS=0 -DMIGRAPHX_HAS_FIND_2_API -DMIGRAPHX_HAS_FIND_MODE_API -DMIGRAPHX_PREALLOCATE_MIOPEN_BUFFERS -DMIGRAPHX_USE_ROCBLAS_FP8_API -DMIGRAPHX_USE_ROCBLAS_TUNING_API -DROCBLAS_BETA_FEATURES_API -DROCBLAS_NO_DEPRECATED_WARNINGS -DUSE_PROF_API=1 -D__HIP_PLATFORM_AMD__ -D__HIP_PLATFORM_AMD__=1 -I/src_projects/AMDMIGraphX/test/include -I/builddir/035_AMDMIGraphX/src/include -I/src_projects/AMDMIGraphX/src/include -I/builddir/035_AMDMIGraphX/src/onnx/include -I/builddir/035_AMDMIGraphX/src/tf/include -I/builddir/035_AMDMIGraphX/src/targets/ref/include -I/src_projects/AMDMIGraphX/src/targets/ref/include -I/builddir/035_AMDMIGraphX/src/targets/gpu/include -I/src_projects/AMDMIGraphX/src/targets/gpu/include -isystem /opt/rocm_sdk_611/include -O3 -DNDEBUG -std=c++17 -Wall -Wextra -Wcomment -Wendif-labels -Wformat -Winit-self -Wreturn-type -Wsequence-point -Wswitch -Wtrigraphs -Wundef -Wuninitialized -Wunreachable-code -Wunused -Wno-sign-compare -Weverything -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-conversion -Wno-double-promotion -Wno-exit-time-destructors -Wno-extra-semi -Wno-extra-semi-stmt -Wno-float-conversion -Wno-gnu-anonymous-struct -Wno-gnu-zero-variadic-macro-arguments -Wno-missing-prototypes -Wno-nested-anon-types -Wno-option-ignored -Wno-padded -Wno-shorten-64-to-32 -Wno-sign-conversion -Wno-unused-command-line-argument -Wno-weak-vtables -Wno-c99-extensions -Wno-unsafe-buffer-usage -MD -MT test/CMakeFiles/header_src_include_migraphx_execution_environment_hpp.dir/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp.o -MF CMakeFiles/header_src_include_migraphx_execution_environment_hpp.dir/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp.o.d -o CMakeFiles/header_src_include_migraphx_execution_environment_hpp.dir/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp.o -c /builddir/035_AMDMIGraphX/test/header-static-include-header_src_include_migraphx_execution_environment_hpp.cpp
+In file included from /builddir/035_AMDMIGraphX/test/header-main-include-header_src_include_migraphx_convolution_hpp.cpp:2:
+In file included from /src_projects/AMDMIGraphX/src/include/migraphx/convolution.hpp:29:
+In file included from /src_projects/AMDMIGraphX/src/include/migraphx/par_for.hpp:27:
+/src_projects/AMDMIGraphX/src/include/migraphx/par.hpp:58:22: error: no member named 'exception_ptr' in namespace 'std'
    58 |     std::vector<std::exception_ptr> exceptions;
 
 Signed-off-by: Mika Laitio <lamikr@gmail.com>
@@ -46,5 +46,5 @@ index 270d0f07b..46b27f516 100644
  OutputIt par_transform(InputIt first1, InputIt last1, OutputIt d_first, UnaryOperation unary_op)
  {
 -- 
-2.45.1
+2.43.0
 

--- a/patches/rocm-6.1.1/AMDMIGraphX/0004-AMDMIGraphX-msgpack-cxx-ubuntu-24.04-search-fix.patch
+++ b/patches/rocm-6.1.1/AMDMIGraphX/0004-AMDMIGraphX-msgpack-cxx-ubuntu-24.04-search-fix.patch
@@ -1,0 +1,57 @@
+From bc663cf5ce68a01646e33c0b222a4faf846f2064 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Sat, 1 Jun 2024 19:06:33 -0700
+Subject: [PATCH 4/4] AMDMIGraphX msgpack-cxx ubuntu 24.04 search fix
+
+Ubuntu 24.04 has renamed msgpackc-cxx to
+msgpack-cxx and AMDMIGraphX configure failed to
+find it and eventually failed on linking phase.
+(msgpack itself was found but not -cxx extensions)
+
+Fix by searching first the msgpackc-cxx and if that
+fails search the msgpack-cxx
+
+https://github.com/lamikr/rocm_sdk_builder/issues/11
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ src/CMakeLists.txt | 22 +++++++++++++++++-----
+ 1 file changed, 17 insertions(+), 5 deletions(-)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 55ede3227..99d6453d9 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -296,12 +296,24 @@ find_package(SQLite3 REQUIRED)
+ target_link_libraries(migraphx PRIVATE SQLite::SQLite3)
+ 
+ find_package(msgpackc-cxx QUIET)
+-if(NOT msgpackc-cxx_FOUND)
+-    find_package(msgpack REQUIRED)
++if(msgpackc-cxx_FOUND)
++    target_link_libraries(migraphx PRIVATE msgpackc-cxx)
++    # Make this available to the tests
++    target_link_libraries(migraphx INTERFACE $<BUILD_INTERFACE:msgpackc-cxx>)
++else()
++    #ubuntu 24.04 renamed msgpackc-cxx to msgpack-cxx, so search also that name
++    find_package(msgpack-cxx QUIET)
++    if(msgpack-cxx_FOUND)
++        target_link_libraries(migraphx PRIVATE msgpack-cxx)
++        # Make this available to the tests
++        target_link_libraries(migraphx INTERFACE $<BUILD_INTERFACE:msgpack-cxx>)
++    else()
++        find_package(msgpack REQUIRED)
++        target_link_libraries(migraphx PRIVATE msgpackc-cxx)
++        # Make this available to the tests
++        target_link_libraries(migraphx INTERFACE $<BUILD_INTERFACE:msgpackc-cxx>)
++    endif()
+ endif()
+-target_link_libraries(migraphx PRIVATE msgpackc-cxx)
+-# Make this available to the tests
+-target_link_libraries(migraphx INTERFACE $<BUILD_INTERFACE:msgpackc-cxx>)
+ 
+ add_library(migraphx_all_targets INTERFACE)
+ 
+-- 
+2.43.0
+


### PR DESCRIPTION
patch to search msgpack-cxx in addition of
msgpackc-cxx due to package rename in Ubuntu 24.04

fixes: https://github.com/lamikr/rocm_sdk_builder/issues/11