### PR TITLE
temporarily rocm_smi_lib library soname fix

### DIFF
--- a/patches/rocm-6.1.1/rocm_smi_lib/0001-fix-the-modify-of-readonly-object-detected-by-gcc_14.patch
+++ b/patches/rocm-6.1.1/rocm_smi_lib/0001-fix-the-modify-of-readonly-object-detected-by-gcc_14.patch
@@ -1,7 +1,7 @@
-From b58f177e3886930d61ef77262b55b64e861e3957 Mon Sep 17 00:00:00 2001
+From b224d7babbe0689b55e22a3fd0e86db990e312a7 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Wed, 29 May 2024 10:27:38 -0700
-Subject: [PATCH] fix the modify of readonly object detected by gcc_14
+Subject: [PATCH 1/3] fix the modify of readonly object detected by gcc_14
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -38,5 +38,5 @@ index 40f24ec..0b32148 100755
      release_ = rhs.release_;
      rhs.dismiss_ = true;
 -- 
-2.45.1
+2.41.1
 

--- a/patches/rocm-6.1.1/rocm_smi_lib/0002-workaround-for-missing-rsmi_pkg_ver-git-tags.patch
+++ b/patches/rocm-6.1.1/rocm_smi_lib/0002-workaround-for-missing-rsmi_pkg_ver-git-tags.patch
@@ -1,0 +1,72 @@
+From f555a43f00e49818375de555666bde2027c24ca8 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Thu, 6 Jun 2024 10:21:09 -0700
+Subject: [PATCH 2/3] workaround for missing rsmi_pkg_ver git tags
+
+use the suggested default versions of tags
+(7.0.0 in rocm-6.1.1 for example) instead
+of trying to parse it from rsmi_pkg_ver git tag.
+
+Because those are not uptodate on github repo,
+the version returned would be old 2.8.0
+instead of current 7.0.0 causing problems
+at least for rocm-smi.
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ cmake_modules/utils.cmake | 4 ++--
+ oam/CMakeLists.txt        | 2 +-
+ rocm_smi/CMakeLists.txt   | 2 +-
+ 3 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/cmake_modules/utils.cmake b/cmake_modules/utils.cmake
+index 7131761..823bfc1 100755
+--- a/cmake_modules/utils.cmake
++++ b/cmake_modules/utils.cmake
+@@ -44,7 +44,6 @@
+ ## the first, second and third number values in
+ ## the major, minor and patch variables.
+ function( parse_version VERSION_STRING )
+-
+     string ( FIND ${VERSION_STRING} "-" STRING_INDEX )
+ 
+     if ( ${STRING_INDEX} GREATER -1 )
+@@ -84,7 +83,8 @@ endfunction ()
+ function(get_version_from_tag DEFAULT_VERSION_STRING VERSION_PREFIX GIT)
+     parse_version ( ${DEFAULT_VERSION_STRING} )
+ 
+-    if ( GIT )
++    # https://github.com/ROCm/rocm_smi_lib/issues/178
++    if ( rsmi_pkg_ver_GIT_TAGS_ARE_UP_TODATE )
+         execute_process ( COMMAND git describe --tags --dirty --long --match ${VERSION_PREFIX}-[0-9.]*
+                           WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                           OUTPUT_VARIABLE GIT_TAG_STRING
+diff --git a/oam/CMakeLists.txt b/oam/CMakeLists.txt
+index 6927d24..0ca8b5d 100644
+--- a/oam/CMakeLists.txt
++++ b/oam/CMakeLists.txt
+@@ -37,7 +37,7 @@ message("Package version: ${PKG_VERSION_STR}")
+ 
+ # Debian package specific variables
+ # Set a default value for the package version
+-get_version_from_tag("1.0.0.0" ${SO_VERSION_GIT_TAG_PREFIX} GIT)
++get_version_from_tag("7.0.0.0" ${SO_VERSION_GIT_TAG_PREFIX} GIT)
+ 
+ # VERSION_* variables should be set by get_version_from_tag
+ if ( ${ROCM_PATCH_VERSION} )
+diff --git a/rocm_smi/CMakeLists.txt b/rocm_smi/CMakeLists.txt
+index 012ce9a..5c691b2 100755
+--- a/rocm_smi/CMakeLists.txt
++++ b/rocm_smi/CMakeLists.txt
+@@ -39,7 +39,7 @@ message("Package version: ${PKG_VERSION_STR}")
+ 
+ # Debian package specific variables
+ # Set a default value for the package version
+-get_version_from_tag("1.0.0.0" ${SO_VERSION_GIT_TAG_PREFIX} GIT)
++get_version_from_tag("7.0.0.0" ${SO_VERSION_GIT_TAG_PREFIX} GIT)
+ 
+ # VERSION_* variables should be set by get_version_from_tag
+ if ( ${ROCM_PATCH_VERSION} )
+-- 
+2.41.1
+

--- a/patches/rocm-6.1.1/rocm_smi_lib/0003-search-library-both-from-the-lib64-and-lib.patch
+++ b/patches/rocm-6.1.1/rocm_smi_lib/0003-search-library-both-from-the-lib64-and-lib.patch
@@ -1,0 +1,28 @@
+From 91ace67bc4898c0148a32849bb0eee63d64a4c5a Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Thu, 6 Jun 2024 10:51:14 -0700
+Subject: [PATCH 3/3] search library both from the lib64 and lib
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ python_smi_tools/rsmiBindings.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/python_smi_tools/rsmiBindings.py b/python_smi_tools/rsmiBindings.py
+index 3cd2e9f..0ae20c7 100644
+--- a/python_smi_tools/rsmiBindings.py
++++ b/python_smi_tools/rsmiBindings.py
+@@ -26,7 +26,9 @@ def initRsmiBindings(silent=False):
+     if (rocm_smi_lib_path != None):
+         path_librocm = rocm_smi_lib_path
+     else:
+-        path_librocm = os.path.dirname(os.path.realpath(__file__)) + '/../../lib/librocm_smi64.so.7'
++        path_librocm = os.path.dirname(os.path.realpath(__file__)) + '/../../lib64/librocm_smi64.so.7'
++        if not os.path.isfile(path_librocm):
++            path_librocm = os.path.dirname(os.path.realpath(__file__)) + '/../../lib/librocm_smi64.so.7'
+ 
+     if not os.path.isfile(path_librocm):
+         print_silent('Unable to find %s . Trying /opt/rocm*' % path_librocm)
+-- 
+2.41.1
+


### PR DESCRIPTION
- patch soname issue by hardcoding the version number to 7.0.0 until the git hashes are set to public github repo.
- if ROCM_SMI_LIB_PATH is not set use also the lib64 in addition of lib for searching the librocm_smi64.so.7

fixes: https://github.com/lamikr/rocm_sdk_builder/issues/61