### PR TITLE
Fix crash on any shell other than bash

### DIFF
--- a/binfo/env/need_to_be_sourced.sh
+++ b/binfo/env/need_to_be_sourced.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # This script needs to be sourced
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/binfo/env/need_to_be_sourced.sh
+++ b/binfo/env/need_to_be_sourced.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script needs to be sourced
-if [[ "$0" != *"sh"*]]; then
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     echo "Script execution failed. Please use the following command to source the script:"
     echo "    source $0"
     echo ""

--- a/binfo/env/need_to_be_sourced.sh
+++ b/binfo/env/need_to_be_sourced.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # This script needs to be sourced
-if [ "${0:0:4}" != "bash" ] && [ "${0:0:4}" != "-bas" ]; then
+if [[ "$0" != *"sh"*]]; then
     echo "Script execution failed. Please use the following command to source the script:"
     echo "    source $0"
     echo ""


### PR DESCRIPTION
The "need_to_be_sourced.sh" script crashes on any shell other than bash.

This small change should allow the script to work fine on any linux shell.