### PR TITLE
Fix missing optimization for amd-fftw & upgrade to 4.2

### DIFF
--- a/binfo/020_01_amd_fftw_single_precision.binfo
+++ b/binfo/020_01_amd_fftw_single_precision.binfo
@@ -3,9 +3,10 @@ BINFO_APP_SRC_SUBDIR_BASENAME=
 BINFO_APP_SRC_TOPDIR_BASENAME=${BINFO_APP_NAME}
 BINFO_APP_SRC_DIR="${SDK_SRC_ROOT_DIR}/${BINFO_APP_SRC_TOPDIR_BASENAME}"
 BINFO_APP_UPSTREAM_REPO_URL=https://github.com/amd/amd-fftw.git
-BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.1
+BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.2
 
 BINFO_APP_CONFIG_CMD_ARRAY=(
     "cd ${BINFO_APP_BUILD_DIR}"
+    "export CFLAGS=\"${CFLAGS} -O3\""
     "${BINFO_APP_SRC_DIR}/configure --enable-sse2 --enable-avx --enable-avx2 --enable-avx512 --enable-mpi --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --enable-single --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
 )

--- a/binfo/020_02_amd_fftw_double_precision.binfo
+++ b/binfo/020_02_amd_fftw_double_precision.binfo
@@ -3,9 +3,10 @@ BINFO_APP_SRC_SUBDIR_BASENAME=
 BINFO_APP_SRC_TOPDIR_BASENAME=${BINFO_APP_NAME}
 BINFO_APP_SRC_DIR="${SDK_SRC_ROOT_DIR}/${BINFO_APP_SRC_TOPDIR_BASENAME}"
 BINFO_APP_UPSTREAM_REPO_URL=https://github.com/amd/amd-fftw.git
-BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.1
+BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.2
 
 BINFO_APP_CONFIG_CMD_ARRAY=(
     "cd ${BINFO_APP_BUILD_DIR}"
+    "export CFLAGS=\"${CFLAGS} -O3\""
     "${BINFO_APP_SRC_DIR}/configure --enable-sse2 --enable-avx --enable-avx2 --enable-avx512 --enable-mpi --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
 )

--- a/binfo/020_03_amd_fftw_long_double_precision.binfo
+++ b/binfo/020_03_amd_fftw_long_double_precision.binfo
@@ -3,9 +3,10 @@ BINFO_APP_SRC_SUBDIR_BASENAME=
 BINFO_APP_SRC_TOPDIR_BASENAME=${BINFO_APP_NAME}
 BINFO_APP_SRC_DIR="${SDK_SRC_ROOT_DIR}/${BINFO_APP_SRC_TOPDIR_BASENAME}"
 BINFO_APP_UPSTREAM_REPO_URL=https://github.com/amd/amd-fftw.git
-BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.1
+BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.2
 
 BINFO_APP_CONFIG_CMD_ARRAY=(
     "cd ${BINFO_APP_BUILD_DIR}"
+    "export CFLAGS=\"${CFLAGS} -O3\""
     "${BINFO_APP_SRC_DIR}/configure --enable-mpi --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --enable-long-double --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
 )

--- a/binfo/020_04_amd_fftw_quad_precision.binfo
+++ b/binfo/020_04_amd_fftw_quad_precision.binfo
@@ -3,9 +3,10 @@ BINFO_APP_SRC_SUBDIR_BASENAME=
 BINFO_APP_SRC_TOPDIR_BASENAME=${BINFO_APP_NAME}
 BINFO_APP_SRC_DIR="${SDK_SRC_ROOT_DIR}/${BINFO_APP_SRC_TOPDIR_BASENAME}"
 BINFO_APP_UPSTREAM_REPO_URL=https://github.com/amd/amd-fftw.git
-BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.1
+BINFO_APP_UPSTREAM_REPO_VERSION_TAG=4.2
 
 BINFO_APP_CONFIG_CMD_ARRAY=(
     "cd ${BINFO_APP_BUILD_DIR}"
+    "export CFLAGS=\"${CFLAGS} -O3\""
     "${BINFO_APP_SRC_DIR}/configure --enable-openmp --enable-shared --enable-amd-opt --enable-amd-mpifft --enable-quad-precision --prefix=${INSTALL_DIR_PREFIX_SDK_ROOT} --libdir=${INSTALL_DIR_PREFIX_SDK_ROOT}/lib64"
 )

--- a/build/build.sh
+++ b/build/build.sh
@@ -186,7 +186,7 @@ func_build_all() {
                         do
                             echo "${BINFO_APP_NAME}, config command ${jj}"
                             echo "${BINFO_APP_CONFIG_CMD_ARRAY[jj]}"
-                            ${BINFO_APP_CONFIG_CMD_ARRAY[jj]}
+                            eval ${BINFO_APP_CONFIG_CMD_ARRAY[jj]} || exit
                             res=$?
                             if [ ${res} -eq 0 ]; then
                                 jj=$(( ${jj} + 1 ))


### PR DESCRIPTION
Per #82, amd-fftw uses `CFLAGS` as a replacement rather than an append, so all options need to be supplied by us. This pull also upgrades to 4.2, because we can.

A vanilla build applies `-O3 -fomit-frame-pointer -mtune=native -malign-double -fstrict-aliasing -fno-schedule-insns`. On a modern GCC build, all of the other options are actually implied by `-O3`, except for two:
* `-mtune=native`. We omit this because a build on a virtual machine might leave us with a badly tuned library.
* `-fno-schedule-insns`. This turns off instruction scheduling. A benchmark on my end showed no improvements from this option, I think it's better to trust the compiler here. Like the other options this might be a holdover from times where GCC's optimization was worse.

This also patches `build.sh` so it can process configure commands with quoted options. The other spots in the file already use `eval`, just this one didn't. I retested the build to ensure this 1) doesn't break anything and 2) the exported `CFLAGS` don't end up on other builds.