### PR TITLE
deepspeed build fix in virtual linux env

### DIFF
--- a/patches/rocm-6.1.2/DeepSpeed/0001-deepspeed-rocm-preconfig-and-build_install-scripts.patch
+++ b/patches/rocm-6.1.2/DeepSpeed/0001-deepspeed-rocm-preconfig-and-build_install-scripts.patch
@@ -1,7 +1,7 @@
-From 69e95609c918f8e0e38b9cdcdc4961bbbb922f60 Mon Sep 17 00:00:00 2001
+From 65f5eac2c5b3e4e8bd369969711096529c695ed0 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Mon, 20 May 2024 22:36:23 -0700
-Subject: [PATCH 1/3] deepspeed rocm preconfig and build_install scripts
+Subject: [PATCH 1/4] deepspeed rocm preconfig and build_install scripts
 
 discussed here:
 https://github.com/microsoft/DeepSpeed/issues/4989
@@ -55,5 +55,5 @@ index 00000000..1730e027
 +    fi
 +fi
 -- 
-2.41.1
+2.45.2
 

--- a/patches/rocm-6.1.2/DeepSpeed/0002-check-rocm-path-from-installed-pytorch-variables.patch
+++ b/patches/rocm-6.1.2/DeepSpeed/0002-check-rocm-path-from-installed-pytorch-variables.patch
@@ -1,7 +1,7 @@
-From 301ea4a7cb40db991673b823fab91a22a04b3a18 Mon Sep 17 00:00:00 2001
+From 9db05277659860181c8de16c8bda427fe4ff5d4f Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Tue, 21 May 2024 07:57:53 -0700
-Subject: [PATCH 2/3] check rocm path from installed pytorch variables
+Subject: [PATCH 2/4] check rocm path from installed pytorch variables
 
 - Use ROCM_HOME variable from the installed pytorch
   also for checking path where to call rocminfo
@@ -72,5 +72,5 @@ index df54415c..a27b134c 100644
          OpBuilder._rocm_wavefront_size = rocm_wavefront_size
          return OpBuilder._rocm_wavefront_size
 -- 
-2.41.1
+2.45.2
 

--- a/patches/rocm-6.1.2/DeepSpeed/0003-remove-linear_kernel-which-fails-on-rocm.patch
+++ b/patches/rocm-6.1.2/DeepSpeed/0003-remove-linear_kernel-which-fails-on-rocm.patch
@@ -1,7 +1,7 @@
-From e6db2a2a867d261891bbd4d77b4dd70c55e4e8fb Mon Sep 17 00:00:00 2001
+From 0bec9198e6933979cfd7234350a85501ff182532 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Tue, 21 May 2024 11:41:20 -0700
-Subject: [PATCH 3/3] remove linear_kernel which fails on rocm
+Subject: [PATCH 3/4] remove linear_kernel which fails on rocm
 
 - build fails on rocm 6.1.1
 
@@ -57,5 +57,5 @@ index d1957f39..f5538c34 100755
          ]
  
 -- 
-2.41.1
+2.45.2
 

--- a/patches/rocm-6.1.2/DeepSpeed/0004-allow-building-deepspeed-for-rocm-in-virtual-linux.patch
+++ b/patches/rocm-6.1.2/DeepSpeed/0004-allow-building-deepspeed-for-rocm-in-virtual-linux.patch
@@ -1,0 +1,88 @@
+From aa9574025ea9fbd6c4781f8a8775410ae0862048 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Wed, 26 Jun 2024 14:44:04 -0700
+Subject: [PATCH 4/4] allow building deepspeed for rocm in virtual linux
+
+enable the deepspeed rocm build on virtual linux env
+without access to real GPU. (gpu list is also passed as a parameter)
+
+fixes: https://github.com/lamikr/rocm_sdk_builder/issues/75
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ build_and_install_rocm.sh |  2 ++
+ op_builder/builder.py     |  2 +-
+ setup.py                  | 18 ++++++++++--------
+ 3 files changed, 13 insertions(+), 9 deletions(-)
+
+diff --git a/build_and_install_rocm.sh b/build_and_install_rocm.sh
+index 68e96b40..7a504cf4 100755
+--- a/build_and_install_rocm.sh
++++ b/build_and_install_rocm.sh
+@@ -15,6 +15,8 @@ mkdir -p deepspeed/ops/spatial
+ #export CFLAGS="-I/usr/include"
+ #export LDFLAGS="-L/usr/lib64"
+ 
++# needed by real accelerator.py to detect the cuda when build on virtual linux without access to real hardware
++export DS_ACCELERATOR=cuda
+ # install command will create wheel and install it. bdist_wheel comamnd would only create the wheel
+ AMDGPU_TARGETS=${amd_target_gpu} DS_BUILD_AIO=0 DS_BUILD_FP_QUANTIZER=0 DS_BUILD_QUANTIZER=0 DS_BUILD_SPARSE_ATTN=0 DS_BUILD_RAGGED_DEVICE_OPS=0 DS_BUILD_CUTLASS_OPS=0 DS_BUILD_EVOFORMER_ATTN=0 DS_BUILD_OPS=1 python setup.py install
+ 
+diff --git a/op_builder/builder.py b/op_builder/builder.py
+index a27b134c..4980a528 100644
+--- a/op_builder/builder.py
++++ b/op_builder/builder.py
+@@ -512,7 +512,7 @@ class OpBuilder(ABC):
+             # Ensure the op we're about to load was compiled with the same
+             # torch/cuda versions we are currently using at runtime.
+             self.validate_torch_version(torch_info)
+-            if torch.cuda.is_available() and isinstance(self, CUDAOpBuilder):
++            if (self.is_rocm_pytorch() or torch.cuda.is_available()) and isinstance(self, CUDAOpBuilder):
+                 self.validate_torch_op_version(torch_info)
+ 
+             op_module = importlib.import_module(self.absolute_name())
+diff --git a/setup.py b/setup.py
+index 408b300a..cbeda1eb 100755
+--- a/setup.py
++++ b/setup.py
+@@ -90,19 +90,21 @@ extras_require = {
+ }
+ 
+ # Add specific cupy version to both onebit extension variants.
+-if torch_available and torch.cuda.is_available():
+-    cupy = None
++if torch_available:
+     if is_rocm_pytorch:
++        cupy = None
+         rocm_major, rocm_minor = rocm_version
+         # XXX cupy support for rocm 5 is not available yet.
+         if rocm_major <= 4:
+             cupy = f"cupy-rocm-{rocm_major}-{rocm_minor}"
+     else:
+-        cuda_major_ver, cuda_minor_ver = installed_cuda_version()
+-        if (cuda_major_ver < 11) or ((cuda_major_ver == 11) and (cuda_minor_ver < 3)):
+-            cupy = f"cupy-cuda{cuda_major_ver}{cuda_minor_ver}"
+-        else:
+-            cupy = f"cupy-cuda{cuda_major_ver}x"
++        if toch.cuda.is_available():
++            cupy = None
++            cuda_major_ver, cuda_minor_ver = installed_cuda_version()
++            if (cuda_major_ver < 11) or ((cuda_major_ver == 11) and (cuda_minor_ver < 3)):
++                cupy = f"cupy-cuda{cuda_major_ver}{cuda_minor_ver}"
++            else:
++                cupy = f"cupy-cuda{cuda_major_ver}x"
+ 
+     if cupy:
+         extras_require['1bit'].append(cupy)
+@@ -130,7 +132,7 @@ else:
+     TORCH_MAJOR = "0"
+     TORCH_MINOR = "0"
+ 
+-if torch_available and not torch.cuda.is_available():
++if torch_available and not is_rocm_pytorch and not torch.cuda.is_available():
+     # Fix to allow docker builds, similar to https://github.com/NVIDIA/apex/issues/486.
+     print("[WARNING] Torch did not find cuda available, if cross-compiling or running with cpu only "
+           "you can ignore this message. Adding compute capability for Pascal, Volta, and Turing "
+-- 
+2.45.2
+


### PR DESCRIPTION
- enable building of deepspeed for target GPU's on virtual linux environment without access to real GPUs and /dev/kfd driver.
- earlier deepspeed used only the runtime method torch.cuda.is_available() method to check whether to build for rocm/cuda or nvidia cuda, now on rocm case the gpu list can be set as a build parameter. (another patch applied earlier)

fixes: https://github.com/lamikr/rocm_sdk_builder/issues/75