### PR TITLE
add support for FFmpeg7 to pytorch-vision

### DIFF
--- a/patches/rocm-6.1.2/pytorch_vision/0001-pytorch_vision-preconfig-and-build_install-scripts.patch
+++ b/patches/rocm-6.1.2/pytorch_vision/0001-pytorch_vision-preconfig-and-build_install-scripts.patch
@@ -1,7 +1,7 @@
-From cd910de946fd662c7117c88f1edc6eabaddf0d49 Mon Sep 17 00:00:00 2001
+From e33f59b2e3bf5d8f578d90536fcdbf95242b2eeb Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Mon, 11 Dec 2023 09:18:53 -0800
-Subject: [PATCH 1/2] pytorch_vision preconfig and build_install scripts
+Subject: [PATCH 1/3] pytorch_vision preconfig and build_install scripts
 
 Signed-off-by: Mika Laitio <lamikr@gmail.com>
 ---
@@ -48,5 +48,5 @@ index 0000000000..9f71fe83b2
 +    fi
 +fi
 -- 
-2.41.1
+2.45.2
 

--- a/patches/rocm-6.1.2/pytorch_vision/0002-fix-build-error-with-hipcc.patch
+++ b/patches/rocm-6.1.2/pytorch_vision/0002-fix-build-error-with-hipcc.patch
@@ -1,7 +1,7 @@
-From e08a5eb9836b29855533b358b33768274a03db62 Mon Sep 17 00:00:00 2001
+From cb0db21064d95ac85b24a1a124cbb8c89023d30d Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Fri, 26 Jan 2024 15:19:56 -0800
-Subject: [PATCH 2/2] fix build error with hipcc
+Subject: [PATCH 2/3] fix build error with hipcc
 
 Following error occured when building with hipcc
 instead of gcc/g++.
@@ -28,5 +28,5 @@ index d2ed73071a..eada131d32 100644
    return out_tensor;
  }
 -- 
-2.41.1
+2.45.2
 

--- a/patches/rocm-6.1.2/pytorch_vision/0003-Add-compatibility-with-FFMPEG-7.0.patch
+++ b/patches/rocm-6.1.2/pytorch_vision/0003-Add-compatibility-with-FFMPEG-7.0.patch
@@ -1,0 +1,116 @@
+From e76c4df71cad0d30b8ffac23bac7c092c8d00326 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Robert-Andr=C3=A9=20Mauchin?=
+ <30413512+eclipseo@users.noreply.github.com>
+Date: Thu, 6 Jun 2024 16:02:45 +0200
+Subject: [PATCH 3/3] Add compatibility with FFMPEG 7.0
+
+Originally from https://gitlab.archlinux.org/archlinux/packaging/packages/torchvision/-/blob/main/torchvision-ffmpeg7.patch
+
+Co-authored-by: Nicolas Hug <nh.nicolas.hug@gmail.com>
+Co-authored-by: Nicolas Hug <contact@nicolas-hug.com>
+Signed-off-by: Jeroen Mostert <jeroen.mostert@cm.com>
+---
+ torchvision/csrc/io/decoder/audio_sampler.cpp | 18 ++++++++++++++
+ torchvision/csrc/io/decoder/audio_stream.cpp  | 24 +++++++++++++++----
+ 2 files changed, 38 insertions(+), 4 deletions(-)
+
+diff --git a/torchvision/csrc/io/decoder/audio_sampler.cpp b/torchvision/csrc/io/decoder/audio_sampler.cpp
+index e26d788d9c..d46b93ddc6 100644
+--- a/torchvision/csrc/io/decoder/audio_sampler.cpp
++++ b/torchvision/csrc/io/decoder/audio_sampler.cpp
+@@ -48,6 +48,23 @@ bool AudioSampler::init(const SamplerParameters& params) {
+     return false;
+   }
+ 
++#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100)
++  SwrContext* swrContext_ = NULL;
++  AVChannelLayout channel_out;
++  AVChannelLayout channel_in;
++  av_channel_layout_default(&channel_out, params.out.audio.channels);
++  av_channel_layout_default(&channel_in, params.in.audio.channels);
++  int ret = swr_alloc_set_opts2(
++      &swrContext_,
++      &channel_out,
++      (AVSampleFormat)params.out.audio.format,
++      params.out.audio.samples,
++      &channel_in,
++      (AVSampleFormat)params.in.audio.format,
++      params.in.audio.samples,
++      0,
++      logCtx_);
++#else
+   swrContext_ = swr_alloc_set_opts(
+       nullptr,
+       av_get_default_channel_layout(params.out.audio.channels),
+@@ -58,6 +75,7 @@ bool AudioSampler::init(const SamplerParameters& params) {
+       params.in.audio.samples,
+       0,
+       logCtx_);
++#endif
+   if (swrContext_ == nullptr) {
+     LOG(ERROR) << "Cannot allocate SwrContext";
+     return false;
+diff --git a/torchvision/csrc/io/decoder/audio_stream.cpp b/torchvision/csrc/io/decoder/audio_stream.cpp
+index 0f6c57e558..9d7354e02f 100644
+--- a/torchvision/csrc/io/decoder/audio_stream.cpp
++++ b/torchvision/csrc/io/decoder/audio_stream.cpp
+@@ -6,26 +6,36 @@
+ namespace ffmpeg {
+ 
+ namespace {
++static int get_nb_channels(const AVFrame* frame, const AVCodecContext* codec) {
++#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100)
++  return frame ? frame->ch_layout.nb_channels : codec->ch_layout.nb_channels;
++#else
++  return frame ? frame->channels : codec->channels;
++#endif
++}
++
+ bool operator==(const AudioFormat& x, const AVFrame& y) {
+   return x.samples == static_cast<size_t>(y.sample_rate) &&
+-      x.channels == static_cast<size_t>(y.channels) && x.format == y.format;
++      x.channels == static_cast<size_t>(get_nb_channels(&y, nullptr)) &&
++      x.format == y.format;
+ }
+ 
+ bool operator==(const AudioFormat& x, const AVCodecContext& y) {
+   return x.samples == static_cast<size_t>(y.sample_rate) &&
+-      x.channels == static_cast<size_t>(y.channels) && x.format == y.sample_fmt;
++      x.channels == static_cast<size_t>(get_nb_channels(nullptr, &y)) &&
++      x.format == y.sample_fmt;
+ }
+ 
+ AudioFormat& toAudioFormat(AudioFormat& x, const AVFrame& y) {
+   x.samples = y.sample_rate;
+-  x.channels = y.channels;
++  x.channels = get_nb_channels(&y, nullptr);
+   x.format = y.format;
+   return x;
+ }
+ 
+ AudioFormat& toAudioFormat(AudioFormat& x, const AVCodecContext& y) {
+   x.samples = y.sample_rate;
+-  x.channels = y.channels;
++  x.channels = get_nb_channels(nullptr, &y);
+   x.format = y.sample_fmt;
+   return x;
+ }
+@@ -54,9 +64,15 @@ int AudioStream::initFormat() {
+   if (format_.format.audio.samples == 0) {
+     format_.format.audio.samples = codecCtx_->sample_rate;
+   }
++#if LIBAVUTIL_VERSION_INT >= AV_VERSION_INT(57, 28, 100)
++  if (format_.format.audio.channels == 0) {
++    format_.format.audio.channels = codecCtx_->ch_layout.nb_channels;
++  }
++#else
+   if (format_.format.audio.channels == 0) {
+     format_.format.audio.channels = codecCtx_->channels;
+   }
++#endif
+   if (format_.format.audio.format == AV_SAMPLE_FMT_NONE) {
+     format_.format.audio.format = codecCtx_->sample_fmt;
+   }
+-- 
+2.45.2
+


### PR DESCRIPTION
Use the Arch patch to add support for distros with FFmpeg7 (like, well, Arch).

This is not a full solution for FFmpeg7 support since it does not fix pytorch-audio, but it's a step in the right direction, and for Arch/Manjaro if you have `ffmpeg6.1` installed this at least allows the full build to complete.