### PR TITLE
MIOpen improved gfx1010/rx 5700 support

### DIFF
--- a/patches/rocm-6.1.2/MIOpen/0001-Do-not-fail-on-install-for-missing-kdb.bz2-file.patch
+++ b/patches/rocm-6.1.2/MIOpen/0001-Do-not-fail-on-install-for-missing-kdb.bz2-file.patch
@@ -1,7 +1,7 @@
-From cce384ab0c28d8c82cfccdad50875cd09af5504b Mon Sep 17 00:00:00 2001
+From 915a3c074ff1c3694566fd74f2e83003a1253104 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Wed, 8 May 2024 13:48:21 -0700
-Subject: [PATCH 1/3] Do not fail on install for missing kdb.bz2 file
+Subject: [PATCH 1/4] Do not fail on install for missing kdb.bz2 file
 
 Do not fail if kdb.bz2 file for some GPU does not exist because
 these kdb files are not mandatory. Their function is to speed up the
@@ -43,5 +43,5 @@ index 32d9a2e5b..d6c2db704 100644
  endif()
  
 -- 
-2.41.0
+2.41.1
 

--- a/patches/rocm-6.1.2/MIOpen/0002-fix-libroctx64.so-linking-error.patch
+++ b/patches/rocm-6.1.2/MIOpen/0002-fix-libroctx64.so-linking-error.patch
@@ -1,7 +1,7 @@
-From f2919a33b8b323e9eda494ee3d8c8cdb7ff4d60a Mon Sep 17 00:00:00 2001
+From ecb981cd1b66749186404fa76c56237c758953b5 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 3 May 2024 14:15:09 -0700
-Subject: [PATCH 2/3] fix libroctx64.so linking error
+Subject: [PATCH 2/4] fix libroctx64.so linking error
 
 search the library and if found link it from there
 instead of expecting it to be in the ld library path
@@ -31,5 +31,5 @@ index 0741a6023..ae4405eed 100644
  
  ############################################################
 -- 
-2.41.0
+2.41.1
 

--- a/patches/rocm-6.1.2/MIOpen/0003-MIOpen-gfx1010-and-gfx1035-support.patch
+++ b/patches/rocm-6.1.2/MIOpen/0003-MIOpen-gfx1010-and-gfx1035-support.patch
@@ -1,7 +1,7 @@
-From f8b408ae6cf7ba18041831c1385091c2392211c3 Mon Sep 17 00:00:00 2001
+From 6578a68e3226e97716aad12d445632358f2a463e Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Tue, 19 Dec 2023 15:13:46 -0800
-Subject: [PATCH 3/3] MIOpen gfx1010 and gfx1035 support
+Subject: [PATCH 3/4] MIOpen gfx1010 and gfx1035 support
 
 - todo: check gfx1010 specific parts
 
@@ -174,5 +174,5 @@ index 16ce78f04..2ec3eaf09 100644
                         "gfx1101",
                         "gfx1102"};
 -- 
-2.41.0
+2.41.1
 

--- a/patches/rocm-6.1.2/MIOpen/0004-improved-gfx1010-support.patch
+++ b/patches/rocm-6.1.2/MIOpen/0004-improved-gfx1010-support.patch
@@ -1,0 +1,139 @@
+From 5e7803271cbbe475da352ab188f09b345006d9c0 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@pilppa.org>
+Date: Mon, 8 Jul 2024 21:44:10 +0300
+Subject: [PATCH 4/4] improved gfx1010 support
+
+- allows running pytorch gpu benchmark
+  on gfx1010/amd rx 5700
+
+Signed-off-by: Mika Laitio <lamikr@pilppa.org>
+---
+ .../composable_kernel/include/utility/config.hpp              | 4 ++++
+ src/kernels/MIOpenBatchNormBwdSpatial.cl                      | 2 +-
+ src/kernels/MIOpenBatchNormFwdTrainSpatial.cl                 | 2 +-
+ src/kernels/batchnorm_functions.h                             | 2 +-
+ src/solver/batchnorm/backward_spatial_multiple.cpp            | 1 +
+ src/solver/batchnorm/backward_spatial_single.cpp              | 1 +
+ src/solver/batchnorm/forward_spatial_multiple.cpp             | 1 +
+ src/solver/batchnorm/forward_spatial_single.cpp               | 1 +
+ src/target_properties.cpp                                     | 2 +-
+ 9 files changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/src/composable_kernel/composable_kernel/include/utility/config.hpp b/src/composable_kernel/composable_kernel/include/utility/config.hpp
+index c0765d93d..5957a79d8 100644
+--- a/src/composable_kernel/composable_kernel/include/utility/config.hpp
++++ b/src/composable_kernel/composable_kernel/include/utility/config.hpp
+@@ -55,6 +55,10 @@
+ #define CK_USE_AMD_V_DOT4_I32_I8
+ #endif
+ 
++#ifdef CK_AMD_GPU_GFX1010
++    #define CK_USE_AMD_V_FMAC_F32
++#endif
++
+ // multi index
+ #define CK_USE_DYNAMICALLY_INDEXED_MULTI_INDEX 0
+ 
+diff --git a/src/kernels/MIOpenBatchNormBwdSpatial.cl b/src/kernels/MIOpenBatchNormBwdSpatial.cl
+index 23103198a..c4682a3b0 100644
+--- a/src/kernels/MIOpenBatchNormBwdSpatial.cl
++++ b/src/kernels/MIOpenBatchNormBwdSpatial.cl
+@@ -33,7 +33,7 @@
+ #endif
+ 
+ #define MIOPEN_USE_AMDGCN 0
+-#if defined(__AMDGCN__) && !(MIO_BN_GFX103X || MIO_BN_GFX110X)
++#if defined(__AMDGCN__) && !(MIO_BN_GFX101X || MIO_BN_GFX103X || MIO_BN_GFX110X)
+ #undef MIOPEN_USE_AMDGCN
+ #define MIOPEN_USE_AMDGCN 1
+ #endif
+diff --git a/src/kernels/MIOpenBatchNormFwdTrainSpatial.cl b/src/kernels/MIOpenBatchNormFwdTrainSpatial.cl
+index 9eecb6990..1d9f84c94 100644
+--- a/src/kernels/MIOpenBatchNormFwdTrainSpatial.cl
++++ b/src/kernels/MIOpenBatchNormFwdTrainSpatial.cl
+@@ -33,7 +33,7 @@
+ #endif
+ 
+ #define MIOPEN_USE_AMDGCN 0
+-#if defined(__AMDGCN__) && !(MIO_BN_GFX103X || MIO_BN_GFX110X)
++#if defined(__AMDGCN__) && !(MIO_BN_GFX101X || MIO_BN_GFX103X || MIO_BN_GFX110X)
+ #undef MIOPEN_USE_AMDGCN
+ #define MIOPEN_USE_AMDGCN 1
+ #endif
+diff --git a/src/kernels/batchnorm_functions.h b/src/kernels/batchnorm_functions.h
+index 4764324db..87fef51cd 100644
+--- a/src/kernels/batchnorm_functions.h
++++ b/src/kernels/batchnorm_functions.h
+@@ -133,7 +133,7 @@
+ // MIOPEN_USE_AMDGCN may be defined before this header.
+ #ifndef MIOPEN_USE_AMDGCN
+ #if defined(__AMDGCN__) && \
+-    !((defined(MIO_BN_GFX103X) && MIO_BN_GFX103X) || (defined(MIO_BN_GFX110X) && MIO_BN_GFX110X))
++    !((defined(MIO_BN_GFX101X) && MIO_BN_GFX101X) || (defined(MIO_BN_GFX103X) && MIO_BN_GFX103X) || (defined(MIO_BN_GFX110X) && MIO_BN_GFX110X))
+ #define MIOPEN_USE_AMDGCN 1
+ #else
+ #define MIOPEN_USE_AMDGCN 0
+diff --git a/src/solver/batchnorm/backward_spatial_multiple.cpp b/src/solver/batchnorm/backward_spatial_multiple.cpp
+index 5daed1982..6b23b52e5 100644
+--- a/src/solver/batchnorm/backward_spatial_multiple.cpp
++++ b/src/solver/batchnorm/backward_spatial_multiple.cpp
+@@ -220,6 +220,7 @@ ConvSolution BnBwdTrainingSpatialMultiple::GetSolution(
+             {"MIO_BN_GRP0", xlocalsize},
+             {"MIO_BN_GRP1", ylocalsize},
+             {"MIO_BN_GRP2", zlocalsize},
++	    {"MIO_BN_GFX101X", (StartsWith(handle.GetDeviceName(), "gfx101") ? "1" : "0")},
+             {"MIO_BN_GFX103X", (StartsWith(handle.GetDeviceName(), "gfx103") ? "1" : "0")},
+             {"MIO_BN_GFX110X", (StartsWith(handle.GetDeviceName(), "gfx110") ? "1" : "0")},
+             {"MIO_LAYOUT_NHWC", static_cast<int>(problem.IsLayoutNHWC())},
+diff --git a/src/solver/batchnorm/backward_spatial_single.cpp b/src/solver/batchnorm/backward_spatial_single.cpp
+index 253abd426..4746e7559 100644
+--- a/src/solver/batchnorm/backward_spatial_single.cpp
++++ b/src/solver/batchnorm/backward_spatial_single.cpp
+@@ -259,6 +259,7 @@ BnBwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
+             build_params << KernelBuildParameters{
+                 {"MIO_BN_GFX110X", (StartsWith(handle.GetDeviceName(), "gfx110") ? "1" : "0")},
+                 {"MIO_BN_GFX103X", (StartsWith(handle.GetDeviceName(), "gfx103") ? "1" : "0")},
++		{"MIO_BN_GFX101X", (StartsWith(handle.GetDeviceName(), "gfx101") ? "1" : "0")},
+             };
+ 
+             kernel.comp_options = build_params.GenerateFor(kbp::OpenCL{});
+diff --git a/src/solver/batchnorm/forward_spatial_multiple.cpp b/src/solver/batchnorm/forward_spatial_multiple.cpp
+index 00ddf4fcc..a50fdd3e6 100644
+--- a/src/solver/batchnorm/forward_spatial_multiple.cpp
++++ b/src/solver/batchnorm/forward_spatial_multiple.cpp
+@@ -176,6 +176,7 @@ ConvSolution BnFwdTrainingSpatialMultiple::GetSolution(
+             {"MIO_BN_GRP0", xlocalsize},
+             {"MIO_BN_GRP1", ylocalsize},
+             {"MIO_BN_GRP2", zlocalsize},
++            {"MIO_BN_GFX101X", (StartsWith(handle.GetDeviceName(), "gfx101") ? "1" : "0")},
+             {"MIO_BN_GFX103X", (StartsWith(handle.GetDeviceName(), "gfx103") ? "1" : "0")},
+             {"MIO_BN_GFX110X", (StartsWith(handle.GetDeviceName(), "gfx110") ? "1" : "0")},
+             {"MIO_LAYOUT_NHWC", static_cast<int>(problem.IsLayoutNHWC())},
+diff --git a/src/solver/batchnorm/forward_spatial_single.cpp b/src/solver/batchnorm/forward_spatial_single.cpp
+index 9a5b6b2c0..feaae6870 100644
+--- a/src/solver/batchnorm/forward_spatial_single.cpp
++++ b/src/solver/batchnorm/forward_spatial_single.cpp
+@@ -210,6 +210,7 @@ BnFwdTrainingSpatialSingle::GetSolution(const ExecutionContext& context,
+             {"MIO_BN_GRP0", xlocalsize},
+             {"MIO_BN_GRP1", ylocalsize},
+             {"MIO_BN_GRP2", zlocalsize},
++            {"MIO_BN_GFX101X", (StartsWith(handle.GetDeviceName(), "gfx101") ? "1" : "0")},
+             {"MIO_BN_GFX103X", (StartsWith(handle.GetDeviceName(), "gfx103") ? "1" : "0")},
+             {"MIO_BN_GFX110X", (StartsWith(handle.GetDeviceName(), "gfx110") ? "1" : "0")},
+             {"MIO_LAYOUT_NHWC", static_cast<int>(problem.IsLayoutNHWC())},
+diff --git a/src/target_properties.cpp b/src/target_properties.cpp
+index bf02d4d55..c3fa2bd3a 100644
+--- a/src/target_properties.cpp
++++ b/src/target_properties.cpp
+@@ -52,7 +52,7 @@ static std::string GetDeviceNameFromMap(const std::string& in)
+         {"gfx804", "gfx803"},
+         {"Vega10", "gfx900"},
+         {"gfx901", "gfx900"},
+-        {"navi10", "gfx1010"},
++        {"Navi10", "gfx1010"},
+         {"10.3.0 Sienna_Cichlid 18", "gfx1030"},
+         {"Rembrandt", "gfx1035"},
+     };
+-- 
+2.41.1
+


### PR DESCRIPTION
MIOpen fixes for gfx1010 support to allow running the pytoch_gpu_benchmarks from 
https://github.com/lamikr/pytorch-gpu-benchmark with gfx101/amd rx 5000 series (tested on 5700 xt)

fixes: https://github.com/lamikr/rocm_sdk_builder/issues/98