### PR TITLE
torch version (fixes #105)

### DIFF
--- a/patches/rocm-6.1.2/pytorch/0001-pytorch_rocm-preconfig-build-and-install-scripts.patch
+++ b/patches/rocm-6.1.2/pytorch/0001-pytorch_rocm-preconfig-build-and-install-scripts.patch
@@ -1,7 +1,7 @@
-From 3fd845cf506a48e779087b8d2453e2a156e208c5 Mon Sep 17 00:00:00 2001
+From 64a667f85a8318d138a15a9c45e781542b77185f Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Mon, 11 Dec 2023 09:20:07 -0800
-Subject: [PATCH 1/6] pytorch_rocm preconfig, build and install scripts
+Subject: [PATCH 1/7] pytorch_rocm preconfig, build and install scripts
 
 - clean previous build, build wheel and install wheel scripts
 "-Wno-error=maybe-uninitialized" is needed during

--- a/patches/rocm-6.1.2/pytorch/0002-show-error-message-if-ROCM_SOURCE_DIR-not-defined.patch
+++ b/patches/rocm-6.1.2/pytorch/0002-show-error-message-if-ROCM_SOURCE_DIR-not-defined.patch
@@ -1,7 +1,7 @@
-From 909642767f13385d2acf7d904df5db06b1d3a8fa Mon Sep 17 00:00:00 2001
+From 179d0957b7d446586377b1f1dd59f21dbe643561 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 10 May 2024 10:16:19 -0700
-Subject: [PATCH 2/6] show error message if ROCM_SOURCE_DIR not defined
+Subject: [PATCH 2/7] show error message if ROCM_SOURCE_DIR not defined
 
 ROCM_SOURCE_DIR is required by by third_party/kineto module
 and if it is not set, kineto will not find the

--- a/patches/rocm-6.1.2/pytorch/0003-LoadHIP-force-ROCM-detection-and-patches.patch
+++ b/patches/rocm-6.1.2/pytorch/0003-LoadHIP-force-ROCM-detection-and-patches.patch
@@ -1,7 +1,7 @@
-From 622a6eb412ef5839c5910da0d03bb4e061d4e91f Mon Sep 17 00:00:00 2001
+From af3e04e22d50e305422811cc60b5cf799ce9a3b3 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 10 May 2024 10:32:33 -0700
-Subject: [PATCH 3/6] LoadHIP force ROCM detection and patches
+Subject: [PATCH 3/7] LoadHIP force ROCM detection and patches
 
 - set HIP_ROOT_DIR to ROCM_PATH which is set
   by the build scripts

--- a/patches/rocm-6.1.2/pytorch/0004-LoadHIP-lib-and-lib64-search-path-adjustements.patch
+++ b/patches/rocm-6.1.2/pytorch/0004-LoadHIP-lib-and-lib64-search-path-adjustements.patch
@@ -1,7 +1,7 @@
-From 043f85f904000acc0c9680c4094dcdbf56d187e7 Mon Sep 17 00:00:00 2001
+From 374e4f1044d82e3b69b0f0e00daf65bfe629881d Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 10 May 2024 11:11:47 -0700
-Subject: [PATCH 4/6] LoadHIP lib and lib64 search path adjustements
+Subject: [PATCH 4/7] LoadHIP lib and lib64 search path adjustements
 
 - search both lib and lib64 directories
   (note some libs still installed to lib-dir

--- a/patches/rocm-6.1.2/pytorch/0005-fix-gcc-parameter-is-null-optimization-error.patch
+++ b/patches/rocm-6.1.2/pytorch/0005-fix-gcc-parameter-is-null-optimization-error.patch
@@ -1,7 +1,7 @@
-From 9b939062b118322f53a8c284f4cd99721b887fd5 Mon Sep 17 00:00:00 2001
+From 74aff7b057c92d3772b6a64ddfbe3cb13fdfd1af Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 10 May 2024 19:25:50 -0700
-Subject: [PATCH 5/6] fix gcc parameter is null optimization error
+Subject: [PATCH 5/7] fix gcc parameter is null optimization error
 
 https://github.com/pytorch/pytorch/issues/112089
 and

--- a/patches/rocm-6.1.2/pytorch/0006-replace-clamp-with-min-and-max-for-fedora-40-issue.patch
+++ b/patches/rocm-6.1.2/pytorch/0006-replace-clamp-with-min-and-max-for-fedora-40-issue.patch
@@ -1,7 +1,7 @@
-From a6c2edaae6571560cbbd5f61661fc08e88c713d6 Mon Sep 17 00:00:00 2001
+From ea7754ed1fef1bf4196ca64a42e50482bd0c6757 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Fri, 31 May 2024 18:35:12 -0700
-Subject: [PATCH 6/6] replace clamp with min and max for fedora 40 issue
+Subject: [PATCH 6/7] replace clamp with min and max for fedora 40 issue
 
 Fedora 40/gcc 14 throws following error during build time
 for clamp function usage during pytorch build time.

--- a/patches/rocm-6.1.2/pytorch/0007-override-version-check-to-ignore-patches.patch
+++ b/patches/rocm-6.1.2/pytorch/0007-override-version-check-to-ignore-patches.patch
@@ -1,0 +1,32 @@
+From 84c0a10418197083e0f6be8be99f51937f333641 Mon Sep 17 00:00:00 2001
+From: Jeroen Mostert <jeroen.mostert@cm.com>
+Date: Sat, 13 Jul 2024 13:18:54 +0200
+Subject: [PATCH 7/7] override version check to ignore patches
+
+The package version logic only applies the tag version if it matches
+the commit exactly. Our patches mess this up, causing it to use a
+version number that is one lower than the actual version, due to how
+versioning in torch works. Since we know our patches only apply to
+released versions, simply remove the requirement for an exact match.
+
+Signed-off-by: Jeroen Mostert <jeroen.mostert@cm.com>
+---
+ tools/generate_torch_version.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/generate_torch_version.py b/tools/generate_torch_version.py
+index 936896934c..74b110da02 100644
+--- a/tools/generate_torch_version.py
++++ b/tools/generate_torch_version.py
+@@ -26,7 +26,7 @@ def get_sha(pytorch_root: Union[str, Path]) -> str:
+ def get_tag(pytorch_root: Union[str, Path]) -> str:
+     try:
+         tag = subprocess.run(
+-            ["git", "describe", "--tags", "--exact"],
++            ["git", "describe", "--tags", "--abbrev=0"],
+             cwd=pytorch_root,
+             encoding="ascii",
+             capture_output=True,
+-- 
+2.45.2
+


### PR DESCRIPTION
Makes it so we use the latest tagged version of torch. Note that it is also possible to explicitly specify the version number of the build with the `PYTORCH_BUILD_VERSION` and `PYTORCH_BUILD_NUMBER` variables, but I thought this was a cleaner fix as it doesn't require us to specify the version twice or extract it from the binfo (which might not even work if we ever need to fetch a specific commit/branch rather than a tag).