### PR TITLE
explicitly pass pytorch version (fixes #105)

### DIFF
--- a/patches/rocm-6.1.2/pytorch/0001-pytorch_rocm-preconfig-build-and-install-scripts.patch
+++ b/patches/rocm-6.1.2/pytorch/0001-pytorch_rocm-preconfig-build-and-install-scripts.patch
@@ -1,4 +1,4 @@
-From 3fd845cf506a48e779087b8d2453e2a156e208c5 Mon Sep 17 00:00:00 2001
+From 7e9c55ab472aa09a6595d2dc941bb322edc7197a Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Mon, 11 Dec 2023 09:20:07 -0800
 Subject: [PATCH 1/6] pytorch_rocm preconfig, build and install scripts
@@ -6,8 +6,10 @@ Subject: [PATCH 1/6] pytorch_rocm preconfig, build and install scripts
 - clean previous build, build wheel and install wheel scripts
 "-Wno-error=maybe-uninitialized" is needed during
 build time for gcc14/fedora 40.
+- explicitly pass version number for release build.
 
 Signed-off-by: Mika Laitio <lamikr@gmail.com>
+Signed-off-by: Jeroen Mostert <jeroen.mostert@cm.com>
 ---
  build_rocm.sh     | 23 +++++++++++++++++++++++
  install_rocm.sh   | 23 +++++++++++++++++++++++
@@ -19,7 +21,7 @@ Signed-off-by: Mika Laitio <lamikr@gmail.com>
 
 diff --git a/build_rocm.sh b/build_rocm.sh
 new file mode 100755
-index 0000000000..8427d3549a
+index 0000000000..2cc3a7773b
 --- /dev/null
 +++ b/build_rocm.sh
 @@ -0,0 +1,23 @@
@@ -45,7 +47,7 @@ index 0000000000..8427d3549a
 +unset CFLAGS
 +unset CPPFLAGS
 +unset PKG_CONFIG_PATH
-+USE_FLASH_ATTENTION=OFF ROCM_PATH=${install_dir_prefix_rocm} ROCM_SOURCE_DIR=${install_dir_prefix_rocm} CMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS -Wno-error=maybe-uninitialized" CMAKE_PREFIX_PATH="${install_dir_prefix_rocm};${install_dir_prefix_rocm}/lib64/cmake;${install_dir_prefix_rocm}/lib/cmake;${install_dir_prefix_rocm}/lib64;${install_dir_prefix_rocm}/lib" ROCM_VERSION=${rocm_version_str} HIP_ROOT_DIR=${install_dir_prefix_rocm} USE_ROCM=1 python setup.py bdist_wheel
++USE_FLASH_ATTENTION=OFF ROCM_PATH=${install_dir_prefix_rocm} ROCM_SOURCE_DIR=${install_dir_prefix_rocm} CMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS -Wno-error=maybe-uninitialized" CMAKE_PREFIX_PATH="${install_dir_prefix_rocm};${install_dir_prefix_rocm}/lib64/cmake;${install_dir_prefix_rocm}/lib/cmake;${install_dir_prefix_rocm}/lib64;${install_dir_prefix_rocm}/lib" ROCM_VERSION=${rocm_version_str} HIP_ROOT_DIR=${install_dir_prefix_rocm} USE_ROCM=1 PYTORCH_BUILD_VERSION="$(git describe --tags --abbrev=0 | sed 's/^v//')" PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
 diff --git a/install_rocm.sh b/install_rocm.sh
 new file mode 100755
 index 0000000000..38ed0fc21d


### PR DESCRIPTION
If not explicitly specified, pytorch will synthesize a build number from `version.txt`, git commit and/or tags if exactly on a tag, which never produces a release version number. Instead take the most recent tag before any of our patches and use that.

Note that there is seemingly redundant version logic in the Python code itself, but tweaking this does not have the desired effect as this code isn't used everywhere, and in particularly not for the package version number.

An alternative would be to change the `binfo` to pass this information to the script, but I think just getting it locally is cleaner and has less chance for errors (for example, if we choose to pull a specific commit hash).