### PR TITLE
build DeepSpeed in parallel

### DIFF
--- a/patches/rocm-6.1.2/DeepSpeed/0001-deepspeed-rocm-preconfig-and-build_install-scripts.patch
+++ b/patches/rocm-6.1.2/DeepSpeed/0001-deepspeed-rocm-preconfig-and-build_install-scripts.patch
@@ -1,7 +1,7 @@
-From 3d237f904f4f74618da216179f9279fd027b05e8 Mon Sep 17 00:00:00 2001
+From 864b7710609fe2a631ce720c73bcbda5a878c129 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Mon, 20 May 2024 22:36:23 -0700
-Subject: [PATCH 1/4] deepspeed rocm preconfig and build_install scripts
+Subject: [PATCH 1/5] deepspeed rocm preconfig and build_install scripts
 
 discussed here:
 https://github.com/microsoft/DeepSpeed/issues/4989

--- a/patches/rocm-6.1.2/DeepSpeed/0002-check-rocm-path-from-installed-pytorch-variables.patch
+++ b/patches/rocm-6.1.2/DeepSpeed/0002-check-rocm-path-from-installed-pytorch-variables.patch
@@ -1,7 +1,7 @@
-From ff7f27c49a5ac7ac31f7ebc70e02c18f3aa0ac91 Mon Sep 17 00:00:00 2001
+From cf2a742358921ced56b6c1b3f9592fcba7df9cff Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Tue, 21 May 2024 07:57:53 -0700
-Subject: [PATCH 2/4] check rocm path from installed pytorch variables
+Subject: [PATCH 2/5] check rocm path from installed pytorch variables
 
 - Use ROCM_HOME variable from the installed pytorch
   also for checking path where to call rocminfo

--- a/patches/rocm-6.1.2/DeepSpeed/0003-allow-building-deepspeed-for-rocm-in-virtual-linux.patch
+++ b/patches/rocm-6.1.2/DeepSpeed/0003-allow-building-deepspeed-for-rocm-in-virtual-linux.patch
@@ -1,7 +1,7 @@
-From e423db20d2eb75934214c4487fb4193f3df389a9 Mon Sep 17 00:00:00 2001
+From 7f8437355bec830020f6d72e8e56e99a4f8675d6 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Wed, 26 Jun 2024 14:44:04 -0700
-Subject: [PATCH 3/4] allow building deepspeed for rocm in virtual linux
+Subject: [PATCH 3/5] allow building deepspeed for rocm in virtual linux
 
 enable the deepspeed rocm build on virtual linux env
 without access to real GPU. (gpu list is also passed as a parameter)

--- a/patches/rocm-6.1.2/DeepSpeed/0004-remove-linear_kernel-which-fails-on-rocm.patch
+++ b/patches/rocm-6.1.2/DeepSpeed/0004-remove-linear_kernel-which-fails-on-rocm.patch
@@ -1,7 +1,7 @@
-From 44b7a213e104e7f7b9e6f9b7e63f5eb8ff7be88f Mon Sep 17 00:00:00 2001
+From cec8ab382d97b6d038df20542907a6dbdc66a3c3 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Tue, 21 May 2024 11:41:20 -0700
-Subject: [PATCH 4/4] remove linear_kernel which fails on rocm
+Subject: [PATCH 4/5] remove linear_kernel which fails on rocm
 
 - build fails on rocm 6.1.1
 

--- a/patches/rocm-6.1.2/DeepSpeed/0005-build-DeepSpeed-in-parallel.patch
+++ b/patches/rocm-6.1.2/DeepSpeed/0005-build-DeepSpeed-in-parallel.patch
@@ -1,0 +1,25 @@
+From b615bc0a4b12c441cfdcfd7e5ec63b4ac771aa71 Mon Sep 17 00:00:00 2001
+From: Jeroen Mostert <jeroen.mostert@cm.com>
+Date: Sun, 4 Aug 2024 00:38:45 +0200
+Subject: [PATCH 5/5] build DeepSpeed in parallel
+
+Signed-off-by: Jeroen Mostert <jeroen.mostert@cm.com>
+---
+ build_rocm.sh | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build_rocm.sh b/build_rocm.sh
+index b48a0ad9..da7586b9 100755
+--- a/build_rocm.sh
++++ b/build_rocm.sh
+@@ -18,6 +18,6 @@ mkdir -p deepspeed/ops/spatial
+ # needed by real accelerator.py to detect the cuda when build on virtual linux without access to real hardware
+ export DS_ACCELERATOR=cuda
+ # install command will create wheel and install it. bdist_wheel comamnd would only create the wheel
+-AMDGPU_TARGETS="${amd_target_gpu}" DS_BUILD_AIO=0 DS_BUILD_FP_QUANTIZER=0 DS_BUILD_QUANTIZER=0 DS_BUILD_SPARSE_ATTN=0 DS_BUILD_RAGGED_DEVICE_OPS=0 DS_BUILD_CUTLASS_OPS=0 DS_BUILD_EVOFORMER_ATTN=0 DS_BUILD_OPS=1 python setup.py bdist_wheel
++AMDGPU_TARGETS="${amd_target_gpu}" DS_BUILD_AIO=0 DS_BUILD_FP_QUANTIZER=0 DS_BUILD_QUANTIZER=0 DS_BUILD_SPARSE_ATTN=0 DS_BUILD_RAGGED_DEVICE_OPS=0 DS_BUILD_CUTLASS_OPS=0 DS_BUILD_EVOFORMER_ATTN=0 DS_BUILD_OPS=1 python setup.py build_ext -j"${BUILD_CPU_COUNT_MODERATE}" bdist_wheel
+ 
+ #DS_BUILD_UTILS=1 DS_BUILD_CPU_ADAGRAD=1 DS_BUILD_RANDOM_LTD=1 DS_BUILD_CPU_ADAM=1 DS_BUILD_FUSED_ADAM=1 DS_BUILD_FUSED_LAMB=1 DS_BUILD_CCL_COMM=1 python setup.py develop
+-- 
+2.45.2
+


### PR DESCRIPTION
A simple change that allows DeepSpeed to build in parallel like everything else, instead of the agonizingly slow serial build it uses now.