### PR TITLE
Build triton with moderate number of cores

### DIFF
--- a/patches/rocm-6.1.2/triton/0001-triton-rocm-build_and_install-scripts.patch
+++ b/patches/rocm-6.1.2/triton/0001-triton-rocm-build_and_install-scripts.patch
@@ -22,7 +22,7 @@ index 000000000..216108218
 +export TRITON_BUILD_WITH_CLANG_LLD=true
 +# can not call python python/setup.py because then some relative paths are not found
 +cd python
-+python setup.py bdist_wheel -vvv
++MAX_JOBS="${BUILD_CPU_COUNT_MODERATE}" python setup.py bdist_wheel -vvv
 diff --git a/install_rocm.sh b/install_rocm.sh
 new file mode 100755
 index 000000000..85ddb977b


### PR DESCRIPTION
Like aotriton, triton thinks building with twice the number of workers as the system has cores is a good idea. It's not, and doing so makes the build *slower* than it needs to be.

Not sure if we should use `MODERATE` or `SAFE` here; `MODERATE` works on my 12-core, 96 GB system but still consumes a lot of memory that lesser systems might not have.