### PR TITLE
llvm openmp add gfx1011 and gfx1012 as a build targets

### DIFF
--- a/patches/rocm-6.1.2/llvm-project/0001-workaround-OmpxDynCgroupMem-missing-member-name-v.patch
+++ b/patches/rocm-6.1.2/llvm-project/0001-workaround-OmpxDynCgroupMem-missing-member-name-v.patch
@@ -1,7 +1,7 @@
-From 810f520e812af121c0df824dbc6e4f743560292c Mon Sep 17 00:00:00 2001
+From cdfd48c9c0c211c993b2ccd9384fb056f213c9a2 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Fri, 1 Dec 2023 14:15:10 -0800
-Subject: [PATCH 1/4] workaround OmpxDynCgroupMem missing member name 'v'
+Subject: [PATCH 1/5] workaround OmpxDynCgroupMem missing member name 'v'
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
@@ -45,5 +45,5 @@ index 7337102d40e8..ba94d15230b0 100644
  CHECK_REQ_SCALAR_INT_CLAUSE(ThreadLimit, OMPC_thread_limit)
  
 -- 
-2.41.0
+2.46.0
 

--- a/patches/rocm-6.1.2/llvm-project/0002-flang-omp_get_device_num-already-defined-error.patch
+++ b/patches/rocm-6.1.2/llvm-project/0002-flang-omp_get_device_num-already-defined-error.patch
@@ -1,7 +1,7 @@
-From 2b1c00eb1220064604e44fce81e88735e14e7ec1 Mon Sep 17 00:00:00 2001
+From 71153dc4cf9ef72abb3a691c7f5bc822e42172c9 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Mon, 4 Dec 2023 17:22:53 -0800
-Subject: [PATCH 2/4] flang omp_get_device_num already defined error
+Subject: [PATCH 2/5] flang omp_get_device_num already defined error
 
 Signed-off-by: Mika Laitio <lamikr@pilppa.org>
 ---
@@ -25,5 +25,5 @@ index 599ce9bf9a01..ce2f7b998443 100644
              use omp_lib_kinds
              integer (kind=omp_integer_kind) omp_get_num_teams
 -- 
-2.41.0
+2.46.0
 

--- a/patches/rocm-6.1.2/llvm-project/0003-add-lib64-to-libhwloc-search-path.patch
+++ b/patches/rocm-6.1.2/llvm-project/0003-add-lib64-to-libhwloc-search-path.patch
@@ -1,7 +1,7 @@
-From fd63b94800f66ec6912b9e8bf9ff60db0a0940c7 Mon Sep 17 00:00:00 2001
+From a27cdefc097c4fbbe91fe84633ac12702c387af9 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Mon, 29 Jan 2024 20:51:12 -0800
-Subject: [PATCH 3/4] add lib64 to libhwloc search path
+Subject: [PATCH 3/5] add lib64 to libhwloc search path
 
 cmake on ubuntu23.10 finds library only from
 lib, not from lib64w
@@ -26,5 +26,5 @@ index c7c9139d8f8a..ddedefdd4ba3 100644
      # In case libhwloc is static, check_library_exists does not work on static libs
      get_filename_component(LIBOMP_HWLOC_LIBRARY_EXT ${LIBOMP_HWLOC_LIBRARY} EXT)
 -- 
-2.41.0
+2.46.0
 

--- a/patches/rocm-6.1.2/llvm-project/0004-fix-llvm-omptarget-libhsakmt-linking.patch
+++ b/patches/rocm-6.1.2/llvm-project/0004-fix-llvm-omptarget-libhsakmt-linking.patch
@@ -1,7 +1,7 @@
-From 89c41060530c754205197f9325bd8f956dd73e8a Mon Sep 17 00:00:00 2001
+From afadfb0a16dfb655cce286a66e56ab461d7e4306 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Sat, 11 May 2024 13:51:59 -0700
-Subject: [PATCH 4/4] fix llvm omptarget libhsakmt linking
+Subject: [PATCH 4/5] fix llvm omptarget libhsakmt linking
 
 ld.lld: error: unable to find library -lhsakmt
 
@@ -88,5 +88,5 @@ index 1ad4316a9c04..7636cac11119 100644
  
  # libomptarget.so needs to be aware of where the plugins live as they
 -- 
-2.41.0
+2.46.0
 

--- a/patches/rocm-6.1.2/llvm-project/0005-add-gfx1011-and-gfx1012-as-a-build-targets.patch
+++ b/patches/rocm-6.1.2/llvm-project/0005-add-gfx1011-and-gfx1012-as-a-build-targets.patch
@@ -1,0 +1,32 @@
+From da1ba6d25805f5479c7583058dc9ff845b9c0205 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Fri, 16 Aug 2024 15:10:33 -0700
+Subject: [PATCH 5/5] add gfx1011 and gfx1012 as a build targets
+
+Thanks for the GHM-0 for suggestion
+
+- fixes https://github.com/lamikr/rocm_sdk_builder/issues/30
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ openmp/libomptarget/DeviceRTL/CMakeLists.txt | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/openmp/libomptarget/DeviceRTL/CMakeLists.txt b/openmp/libomptarget/DeviceRTL/CMakeLists.txt
+index 66ccb4374322..02fc0f1f0674 100644
+--- a/openmp/libomptarget/DeviceRTL/CMakeLists.txt
++++ b/openmp/libomptarget/DeviceRTL/CMakeLists.txt
+@@ -57,8 +57,8 @@ set(source_directory ${devicertl_base_directory}/src)
+ 
+ set(all_capabilities 35 37 50 52 53 60 61 62 70 72 75 80 86 89 87 90)
+ set(all_amdgpu_architectures "gfx700;gfx701;gfx801;gfx803;gfx900;gfx902;gfx906"
+-                             "gfx908;gfx90a;gfx90c;gfx940;gfx941;gfx942;gfx1010;gfx1030"
+-                             "gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036"
++                             "gfx908;gfx90a;gfx90c;gfx940;gfx941;gfx942;gfx1010;gfx1011;gfx1012"
++                             "gfx1030;gfx1031;gfx1032;gfx1033;gfx1034;gfx1035;gfx1036"
+                              "gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151")
+ set(all_nvptx_architectures "sm_35;sm_37;sm_50;sm_52;sm_53;sm_60;sm_61;sm_62"
+                             "sm_70;sm_72;sm_75;sm_80;sm_86;sm_87;sm_89;sm_90")
+-- 
+2.46.0
+


### PR DESCRIPTION
Fix suggested by GHM-0

- fixes https://github.com/lamikr/rocm_sdk_builder/issues/30