### PR TITLE
pytorch hsa-runtime ubuntu 24.04 linking fix

### DIFF
--- a/patches/rocm-6.1.2/pytorch/0001-pytorch_rocm-preconfig-build-and-install-scripts.patch
+++ b/patches/rocm-6.1.2/pytorch/0001-pytorch_rocm-preconfig-build-and-install-scripts.patch
@@ -1,7 +1,7 @@
-From b2dd83a9f4b0604c6872b9c359b0415f2b7f9373 Mon Sep 17 00:00:00 2001
+From df11229ecfe745a2623ccc83bae4a6e999188f7a Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Mon, 11 Dec 2023 09:20:07 -0800
-Subject: [PATCH 1/8] pytorch_rocm preconfig, build and install scripts
+Subject: [PATCH 1/9] pytorch_rocm preconfig, build and install scripts
 
 - clean previous build, build wheel and install wheel scripts
 "-Wno-error=maybe-uninitialized" is needed during
@@ -109,5 +109,5 @@ index 0000000000..7ad2528e9f
 +fi
 +USE_FLASH_ATTENTION=ON AOTRITON_INSTALLED_PREFIX=${install_dir_prefix_rocm} CMAKE_PREFIX_PATH="${install_dir_prefix_rocm};${install_dir_prefix_rocm}/lib64 python" tools/amd_build/build_amd.py
 -- 
-2.34.1
+2.43.0
 

--- a/patches/rocm-6.1.2/pytorch/0002-show-error-message-if-ROCM_SOURCE_DIR-not-defined.patch
+++ b/patches/rocm-6.1.2/pytorch/0002-show-error-message-if-ROCM_SOURCE_DIR-not-defined.patch
@@ -1,7 +1,7 @@
-From b471fa9081757297020cd7927daed0ff94cd1a34 Mon Sep 17 00:00:00 2001
+From 63d3a6933081bfef77c4098a7feec4d62ecc3c55 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 10 May 2024 10:16:19 -0700
-Subject: [PATCH 2/8] show error message if ROCM_SOURCE_DIR not defined
+Subject: [PATCH 2/9] show error message if ROCM_SOURCE_DIR not defined
 
 ROCM_SOURCE_DIR is required by by third_party/kineto module
 and if it is not set, kineto will not find the
@@ -31,5 +31,5 @@ index c4661e39e1..6e7c87631f 100644
    endif()
  
 -- 
-2.34.1
+2.43.0
 

--- a/patches/rocm-6.1.2/pytorch/0003-LoadHIP-force-ROCM-detection-and-patches.patch
+++ b/patches/rocm-6.1.2/pytorch/0003-LoadHIP-force-ROCM-detection-and-patches.patch
@@ -1,7 +1,7 @@
-From e9f880467f96dd3125a880db8a1a2ef026d8001f Mon Sep 17 00:00:00 2001
+From 0e70059b60bea1f8e619ba9765e792c8c9a7e4d3 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 10 May 2024 10:32:33 -0700
-Subject: [PATCH 3/8] LoadHIP force ROCM detection and patches
+Subject: [PATCH 3/9] LoadHIP force ROCM detection and patches
 
 - set HIP_ROOT_DIR to ROCM_PATH which is set
   by the build scripts
@@ -72,5 +72,5 @@ index fa39156031..d1e8f53445 100644
    message("\n***** Library versions from dpkg *****\n")
    execute_process(COMMAND dpkg -l COMMAND grep rocm-dev COMMAND awk "{print $2 \" VERSION: \" $3}")
 -- 
-2.34.1
+2.43.0
 

--- a/patches/rocm-6.1.2/pytorch/0004-LoadHIP-lib-and-lib64-search-path-adjustements.patch
+++ b/patches/rocm-6.1.2/pytorch/0004-LoadHIP-lib-and-lib64-search-path-adjustements.patch
@@ -1,7 +1,7 @@
-From 7cdb6b42927eabae0073674491ca6fa334aefa26 Mon Sep 17 00:00:00 2001
+From e37dcbee0cbad85ba917d338ab07d8d841a8f56a Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Sat, 27 Jul 2024 19:31:03 -0700
-Subject: [PATCH 4/8] LoadHIP lib and lib64 search path adjustements
+Subject: [PATCH 4/9] LoadHIP lib and lib64 search path adjustements
 
 - search both lib and lib64 directories
   (note some libs still installed to lib-dir
@@ -116,5 +116,5 @@ index d1e8f53445..70fe47a9e6 100644
    # check whether HIP declares new types
    set(file "${PROJECT_BINARY_DIR}/hip_new_types.cc")
 -- 
-2.34.1
+2.43.0
 

--- a/patches/rocm-6.1.2/pytorch/0005-fix-gcc-parameter-is-null-optimization-error.patch
+++ b/patches/rocm-6.1.2/pytorch/0005-fix-gcc-parameter-is-null-optimization-error.patch
@@ -1,7 +1,7 @@
-From 919365c801401916f2a162269162012cd8fe6cbc Mon Sep 17 00:00:00 2001
+From d1ef1b53a682f2c55f11e7f3a7da8779fe396868 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@pilppa.org>
 Date: Fri, 10 May 2024 19:25:50 -0700
-Subject: [PATCH 5/8] fix gcc parameter is null optimization error
+Subject: [PATCH 5/9] fix gcc parameter is null optimization error
 
 https://github.com/pytorch/pytorch/issues/112089
 and
@@ -29,5 +29,5 @@ index ceeb607d52..93f3d66aef 100644
  
  if(INSTALL_TEST)
 -- 
-2.34.1
+2.43.0
 

--- a/patches/rocm-6.1.2/pytorch/0006-replace-clamp-with-min-and-max-for-fedora-40-issue.patch
+++ b/patches/rocm-6.1.2/pytorch/0006-replace-clamp-with-min-and-max-for-fedora-40-issue.patch
@@ -1,7 +1,7 @@
-From d98ba2fd5895990172e8b47b6f0401fdc2fafbe7 Mon Sep 17 00:00:00 2001
+From c4800a04890157b936a37feffd3eaabc1c84c0cd Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Fri, 31 May 2024 18:35:12 -0700
-Subject: [PATCH 6/8] replace clamp with min and max for fedora 40 issue
+Subject: [PATCH 6/9] replace clamp with min and max for fedora 40 issue
 
 Fedora 40/gcc 14 throws following error during build time
 for clamp function usage during pytorch build time.
@@ -40,5 +40,5 @@ index 5682ba2757..862bcb9614 100644
      });
    });
 -- 
-2.34.1
+2.43.0
 

--- a/patches/rocm-6.1.2/pytorch/0007-handle-hipcc-verbose-output-on-dumpversion-command.patch
+++ b/patches/rocm-6.1.2/pytorch/0007-handle-hipcc-verbose-output-on-dumpversion-command.patch
@@ -1,7 +1,7 @@
-From 8564daad2db8b7aa0b2d2dccd6f05039c2a5b71e Mon Sep 17 00:00:00 2001
+From b0b0fe112e5e90efb48f6c0e16cd8fb418e410ab Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Mon, 15 Jul 2024 00:57:55 -0400
-Subject: [PATCH 7/8] handle hipcc verbose output on dumpversion command
+Subject: [PATCH 7/9] handle hipcc verbose output on dumpversion command
 
 Signed-off-by: Mika Laitio <lamikr@gmail.com>
 ---
@@ -31,5 +31,5 @@ index bc1a9d8e6c..665f83f8a9 100644
              minimum_required_version = MINIMUM_MSVC_VERSION
              compiler_info = subprocess.check_output(compiler, stderr=subprocess.STDOUT)
 -- 
-2.34.1
+2.43.0
 

--- a/patches/rocm-6.1.2/pytorch/0008-disable-mpitest-due-to-ubuntu-22.04-linking-failures.patch
+++ b/patches/rocm-6.1.2/pytorch/0008-disable-mpitest-due-to-ubuntu-22.04-linking-failures.patch
@@ -1,7 +1,7 @@
-From 114e025c910d4f53f0f4e9ca8b20e7bb57fa601a Mon Sep 17 00:00:00 2001
+From c52c372019318e0426c75496c3903196d7a6cf27 Mon Sep 17 00:00:00 2001
 From: Mika Laitio <lamikr@gmail.com>
 Date: Fri, 30 Aug 2024 14:07:36 -0700
-Subject: [PATCH 8/8] disable mpitest due to ubuntu 22.04 linking failures
+Subject: [PATCH 8/9] disable mpitest due to ubuntu 22.04 linking failures
 
 - rocm-openmpi that is tried to link contains dependency
   to libpmix.so and on ubuntu 22.04 that is not linked
@@ -44,5 +44,5 @@ index 5c8974836d..5f92023008 100644
      install(TARGETS ProcessGroupMPITest DESTINATION bin)
    endif()
 -- 
-2.34.1
+2.43.0
 

--- a/patches/rocm-6.1.2/pytorch/0009-add-HSA_RUNTIME_64_LIB.patch
+++ b/patches/rocm-6.1.2/pytorch/0009-add-HSA_RUNTIME_64_LIB.patch
@@ -1,0 +1,71 @@
+From fdbdeb77c44372c454ba2bc010b6be8dc2cfc9b0 Mon Sep 17 00:00:00 2001
+From: Mika Laitio <lamikr@gmail.com>
+Date: Sat, 31 Aug 2024 23:28:55 -0700
+Subject: [PATCH 9/9] add HSA_RUNTIME_64_LIB
+
+- ubuntu 24.04 does something very differently
+  with cmake than other distros and fails to
+  build pytorch due to missing dependencies to
+  hsa-runtime64... So for to get it building on\
+  on all distros we need to introduce the
+  HSA_RUNTIME_LIBS
+- disable also the building of pytorch tests
+  which will require special handling
+  of linking hsa-runtime64. On other distros
+  they seem to be disabled by default...
+  (why ubuntu wants to be so different from
+   common standards of linux disroes???)
+
+Signed-off-by: Mika Laitio <lamikr@gmail.com>
+---
+ build_rocm.sh                   | 2 +-
+ cmake/public/LoadHIP.cmake      | 3 +++
+ torch/lib/libshm/CMakeLists.txt | 1 +
+ 3 files changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/build_rocm.sh b/build_rocm.sh
+index 5dedc9b9f8..8215fbac04 100755
+--- a/build_rocm.sh
++++ b/build_rocm.sh
+@@ -20,4 +20,4 @@ unset LDFLAGS
+ unset CFLAGS
+ unset CPPFLAGS
+ unset PKG_CONFIG_PATH
+-USE_FLASH_ATTENTION=ON AOTRITON_INSTALLED_PREFIX=${install_dir_prefix_rocm} ROCM_PATH=${install_dir_prefix_rocm} ROCM_SOURCE_DIR=${install_dir_prefix_rocm} CMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS -Wno-error=maybe-uninitialized" CMAKE_PREFIX_PATH="${install_dir_prefix_rocm};${install_dir_prefix_rocm}/lib64/cmake;${install_dir_prefix_rocm}/lib/cmake;${install_dir_prefix_rocm}/lib64;${install_dir_prefix_rocm}/lib" ROCM_VERSION=${rocm_version_str} HIP_ROOT_DIR=${install_dir_prefix_rocm} USE_ROCM=1 PYTORCH_BUILD_VERSION="$(git describe --tags --abbrev=0 | sed 's/^v//')" PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
++BUILD_TEST=0 USE_FLASH_ATTENTION=ON AOTRITON_INSTALLED_PREFIX=${install_dir_prefix_rocm} ROCM_PATH=${install_dir_prefix_rocm} ROCM_SOURCE_DIR=${install_dir_prefix_rocm} CMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS -Wno-error=maybe-uninitialized" CMAKE_PREFIX_PATH="${install_dir_prefix_rocm};${install_dir_prefix_rocm}/lib64/cmake;${install_dir_prefix_rocm}/lib/cmake;${install_dir_prefix_rocm}/lib64;${install_dir_prefix_rocm}/lib" ROCM_VERSION=${rocm_version_str} HIP_ROOT_DIR=${install_dir_prefix_rocm} USE_ROCM=1 PYTORCH_BUILD_VERSION="$(git describe --tags --abbrev=0 | sed 's/^v//')" PYTORCH_BUILD_NUMBER=1 python setup.py bdist_wheel
+diff --git a/cmake/public/LoadHIP.cmake b/cmake/public/LoadHIP.cmake
+index 70fe47a9e6..a58db43614 100644
+--- a/cmake/public/LoadHIP.cmake
++++ b/cmake/public/LoadHIP.cmake
+@@ -160,6 +160,7 @@ if(HIP_FOUND)
+ 
+   find_package_and_print_version(hip REQUIRED)
+   find_package_and_print_version(hsa-runtime64 REQUIRED)
++  #message(FATAL_ERROR "hsa-runtime64: ${hsa-runtime64}")
+   find_package_and_print_version(amd_comgr REQUIRED)
+   find_package_and_print_version(rocrand REQUIRED)
+   find_package_and_print_version(hiprand REQUIRED)
+@@ -194,6 +195,8 @@ if(HIP_FOUND)
+   find_library(ROCM_HIPRTC_LIB hiprtc HINTS ${ROCM_PATH}/lib ${ROCM_PATH}/lib64)
+   # roctx is part of roctracer
+   find_library(ROCM_ROCTX_LIB roctx64 HINTS ${ROCM_PATH}/lib ${ROCM_PATH}/lib64)
++  # linking does not work otherwise on ubuntu 24.04
++  find_library(HSA_RUNTIME64_LIB hsa-runtime64 HINTS ${ROCM_PATH}/lib ${ROCM_PATH}/lib64)
+ 
+   # check whether HIP declares new types
+   set(file "${PROJECT_BINARY_DIR}/hip_new_types.cc")
+diff --git a/torch/lib/libshm/CMakeLists.txt b/torch/lib/libshm/CMakeLists.txt
+index 8a7329ddab..fba1921bbc 100644
+--- a/torch/lib/libshm/CMakeLists.txt
++++ b/torch/lib/libshm/CMakeLists.txt
+@@ -65,6 +65,7 @@ if(BUILD_LIBTORCHLESS)
+ else()
+   # we need to link directly to c10 here otherwise we miss symbols
+   target_link_libraries(torch_shm_manager PRIVATE shm c10)
++  target_link_libraries(torch_shm_manager PRIVATE ${HSA_RUNTIME64_LIB})
+ endif()
+ set_target_properties(torch_shm_manager PROPERTIES
+   INSTALL_RPATH "${_rpath_portable_origin}/../lib")
+-- 
+2.43.0
+


### PR DESCRIPTION
linking failed on Ubuntu 24.04 for undefined
methods that are available in hsa-runtime64.
Not sure why this is not needed on other distros
like Mageia 9, Ubuntu 22.04 and Fedora 40.