### PR TITLE
Remove typo in binfo_operations.sh

### DIFF
--- a/build/binfo_operations.sh
+++ b/build/binfo_operations.sh
@@ -1,4 +1,4 @@
-Error, source directory where fetch repository does not exist#!/bin/bash
+#!/bin/bash
 
 # reads binfo file and fetches latest sources from the upstream
 # for the repository specified. If the repo has not been initialized


### PR DESCRIPTION
Remove typo on first line of file.

Sending this PR to master, but if you'd like to merge this differently to handle the release branches, feel free to reject and edit on your side.

see #151 