### PR TITLE
Reintroduce babeltrace for Arch

### DIFF
--- a/install_deps.sh
+++ b/install_deps.sh
@@ -61,7 +61,16 @@ func_install_packages()
         arch|manjaro)
             # elevate_if_not_root pacman -Syu
             sudo pacman -S --needed gcc-libs make pkgconf numactl cmake doxygen libelf perl-rename perl-uri perl-file-basedir perl-file-copy-recursive perl-file-listing wget gcc gcc-fortran gcc-libs fakeroot openmp pciutils libdrm vim glew autoconf automake libtool bzip2 xz icu perl libmpack python-pip openssl python-pyopenssl libffi nlohmann-json texinfo extra-cmake-modules sqlite git git-lfs valgrind openpmix flex byacc gettext ninja texlive-basic ocl-icd protobuf pybind11 libaio gmp mpfr libpng libjpeg-turbo python-cppheaderparser msgpack-c msgpack-cxx sox ncurses expat systemd cpio
-            git-lfs install
+            if pacman -Qs babeltrace > /dev/null ; then
+                echo "Babeltrace already installed."
+            else
+                git clone https://aur.archlinux.org/babeltrace.git
+                cd babeltrace
+                makepkg -si
+                cd ..
+                rm -rf babeltrace
+            fi
+	    git-lfs install
             ;;
         void)
             sudo xbps-install -S git-lfs base-devel gcc-fortran cmake doxygen babeltrace-devel bzip2-devel elfutils-devel expat-devel ffmpeg ffmpeg-devel gdb gdbm-devel gmp-devel icu icu-devel json-c++ lcov libaio-devel libdrm-devel libffi-devel libglvnd-devel libgomp-devel libjpeg-turbo-devel liblzma liblzma-devel libnuma-devel libpng-devel libuuid-devel mpfr-devel msgpack-cxx ncurses-devel ninja openssl-devel protobuf protobuf-devel python3-pip python3-pybind11 readline readline-devel sox sqlite sqlite-devel xxd zlib-devel


### PR DESCRIPTION
The `babeltrace` package has been removed from the official Arch repositories a while ago, the package is still present in the AUR but that requires a different approach to be installed.

This package is still needed for building some ROCm packages so the choices here are the following 2:
1. Using an AUR helper such as `paru` or `yay`: this method is very fast for Manjaro users as their distro comes with one of those tools preinstalled but if no AUR helper is installed it requires to build it from source in order to install it.
2. Manually building and installing the package from the AUR.

I've decided to go with the second option as I don't see any reason to force users to build an AUR helper if they don't have one. With or without the AUR helper the `babeltrace` package needs to be built from source so there's no real benefit in using the first choice over the second.